### PR TITLE
Fix new feature: taking parameters into $arguments instead of $value,…

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -675,13 +675,13 @@ class PHPGGC
                     $this->help();
                     return;
                 case 'new':
-                    if(count($arguments) < 1)
+                    if(count($arguments) < 2)
                     {
                         $line = $this->_get_command_line('<Framework> <type>');
                         $this->o($line);
                     }
                     else
-                        $this->new_gc($value, $arguments[0]);
+                        $this->new_gc($arguments[0], $arguments[1]);
                     return;
             }
         }


### PR DESCRIPTION
… changing number of args to 2.

The feature is currently broken as it still consider 'new' argument to have a value, and use $value and $arguments[0] in for calling new_gc, instead of calling it with $arguments[0] and $arguments[1]. Also needed to adapt the $arguments count() check to <2 to ensure there's enough data.