### PR TITLE
self::$type does not show the gadget type when requesting infos.

### DIFF
--- a/lib/PHPGGC/GadgetChain.php
+++ b/lib/PHPGGC/GadgetChain.php
@@ -26,7 +26,7 @@ abstract class GadgetChain
         $infos = [
             'Name' => $this->get_name(),
             'Version' => $this->version,
-            'Type' => self::$type,
+            'Type' => $this::$type,
             'Vector' => $this->vector
         ];
 


### PR DESCRIPTION
Type is empty when requesting info on an existing gadget. Changing self::$type to $this::$type into GadgetChain::__toString should fix this.