### PR TITLE
Don't use file:// wrapper

### DIFF
--- a/lib/PHPGGC/GadgetChain/FileWrite.php
+++ b/lib/PHPGGC/GadgetChain/FileWrite.php
@@ -12,7 +12,7 @@ abstract class FileWrite extends \PHPGGC\GadgetChain
 
     public function process_parameters(array $parameters)
     {
-        $local_path = 'file://' . $parameters['local_path'];
+        $local_path = $parameters['local_path'];
 
         if(!file_exists($local_path))
             throw new \PHPGGC\Exception('Unable to read local file: ' . $parameters['local_path']);


### PR DESCRIPTION
For some reason the `file://` wrapper doesn't seem to work like this on my system (MacOS / PHP 7.1)

```
$ cat info.php 
<?php

phpinfo();
$ php -r 'var_dump(file_exists("file://info.php")) . PHP_EOL;'
bool(false)
$ php -r 'var_dump(file_exists("info.php")) . PHP_EOL;'
bool(true)
```

I'm not seeing any reason why the `file://` wrapper is even needed here...