### PR TITLE
Improvements to polyglot phar generation

### DIFF
--- a/lib/PHPGGC/Phar/Format.php
+++ b/lib/PHPGGC/Phar/Format.php
@@ -52,6 +52,7 @@ abstract class Format
 
 		$phar = new \Phar($path);
         $phar->startBuffering();
+        $phar->addFromString("dummy", 'test');
         $phar->addFromString($this->parameters['filename'], 'test');
         $phar->setStub(
             $this->parameters['prefix'] .

--- a/lib/PHPGGC/Phar/Tar.php
+++ b/lib/PHPGGC/Phar/Tar.php
@@ -132,7 +132,7 @@ class Tar extends Format
         $contents =
             substr($contents, 0, 148) .
             "        " .
-            substr($contents, 156)
+            substr($contents, 156, 344) . "aaaa" . substr($contents, 504)
         ;
     
         $chksum = 0;
@@ -141,8 +141,10 @@ class Tar extends Format
         {
             $chksum += ord(substr($contents, $i, 1));
         }
-    
-        $oct = sprintf("%07o", $chksum);
+
+        // make a checksum that PHP detects as valid, but libmagic doesn't
+        // this ensures that the file will be detected as JPEG and not as tar
+        $oct = sprintf("%06o", $chksum) . "x";
         $contents = substr($contents, 0, 148) . $oct . substr($contents, 155);
         $this->data = $contents;
     }


### PR DESCRIPTION
This change allows building tar polyglot phars that are detected as image by file/libmagic.
It builds upon the fact that libmagic and php use different code to validate the tar checksum.
In particular, php stops as soon as any non-octal digit is found and then just returns the value so far,
while tar will always fail the checksum check if there is a non-octal digit. This is used to construct
a phar that PHP can parse but which isn't detected as tar by file due to the failing checksum.