### PR TITLE
Don't output newline when using PHAR

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -85,10 +85,16 @@ class PHPGGC
      */
     public function output_payload($payload)
     {
-        if(!isset($this->parameters['output']))
-            print($payload . "\n");
+        if(!isset($this->parameters['output'])) 
+        {
+            print($payload);
+            if (!isset($this->parameters['phar']))
+                print('\n');
+        }
         else
+        {
             file_put_contents($this->parameters['output'], $payload);
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes issue #58 .
It will no longer output a newline when the PHAR `-p` option is used.
