### PR TITLE
Updates WordPress/Guzzle gadgets and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Laravel/RCE1                              5.4.27                rce             
 Laravel/RCE2                              5.5.39                rce              __destruct          
 Laravel/RCE3                              5.5.39                rce              __destruct     *    
 Laravel/RCE4                              5.5.39                rce              __destruct          
+Laravel/RCE5                              5.8.30                rce              __destruct     *    
+Laravel/RCE6                              5.5.*                 rce              __destruct     *    
 Magento/FW1                               ? <= 1.9.4.0          file_write       __destruct     *    
 Magento/SQLI1                             ? <= 1.9.4.0          sql_injection    __destruct          
 Monolog/RCE1                              1.18 <= 1.23          rce              __destruct          
@@ -49,14 +51,16 @@ Symfony/FW2                               3.4                   file_write      
 Symfony/RCE1                              3.3                   rce              __destruct     *    
 Symfony/RCE2                              2.3.42 < 2.6          rce              __destruct     *    
 Symfony/RCE3                              2.6 <= 2.8.32         rce              __destruct     *    
-WordPress/Guzzle/RCE1                     4.0.0 <= 6.3.3+       rce              __toString     *    
+ThinkPHP/RCE1                             5.1.x-5.2.x           rce              __destruct     *    
+WordPress/Guzzle/RCE1                     4.0.0 <= 6.4.1+       rce              __toString     *    
+WordPress/Guzzle/RCE2                     4.0.0 <= 6.4.1+       rce              __destruct     *    
 WordPress/P/WooCommerce/RCE1              3.4.0 <= 3.6.2+       rce              __destruct     *    
 WordPress/P/YetAnotherStarsRating/RCE1    ? <= 1.8.6            rce              __destruct     *    
 Yii/RCE1                                  1.1.20                rce              __wakeup       *    
 ZendFramework/FD1                         ? <= 1.12.20          file_delete      __destruct          
 ZendFramework/RCE1                        ? <= 1.12.20          rce              __destruct     *    
 ZendFramework/RCE2                        1.11.12 <= 1.12.20    rce              __toString     *    
-ZendFramework/RCE3                        2.0.1 <= ?            rce              __destruct         
+ZendFramework/RCE3                        2.0.1 <= ?            rce              __destruct     
 ```
 
 Every gadget chain has:

--- a/gadgetchains/WordPress/Guzzle/RCE/1/chain.php
+++ b/gadgetchains/WordPress/Guzzle/RCE/1/chain.php
@@ -4,10 +4,10 @@ namespace GadgetChain\WordPress\Guzzle;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE
 {
-    public static $version = '4.0.0 <= 6.3.3+';
+    public static $version = '4.0.0 <= 6.4.1+';
     public static $vector = '__toString';
     public static $author = 'erwan_lr';
-    public static $informations = 'Tested up to WP 5.2 and Guzzle 6.3.3. Newest versions might also work.';
+    public static $informations = 'Tested up to WP 5.2.4 and Guzzle 6.4.1. Newest versions might also work.';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/WordPress/Guzzle/RCE/2/chain.php
+++ b/gadgetchains/WordPress/Guzzle/RCE/2/chain.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace GadgetChain\WordPress\Guzzle\RCE;
+namespace GadgetChain\WordPress\Guzzle;
 
 class RCE2 extends \PHPGGC\GadgetChain\RCE
 {
-    public static $version = '4.0.0 <= 6.3.3+';
+    public static $version = '4.0.0 <= 6.4.1+';
     public static $vector = '__destruct';
     public static $author = 'Kevinlpd';
-    public static $informations = 'Tested up to WP 5.2 and Guzzle 6.3.3. Newest versions might also work.';
+    public static $informations = 'Tested up to WP 5.2.4 and Guzzle 6.4.1. Newest versions might also work.';
 
     public function generate(array $parameters)
     {


### PR DESCRIPTION
- Fixes wrong namespace for the Wordpress/Guzzle/RCE2 gadget
- Updates the latest working version for Wordpress/Guzzle/RCE gadgets
- Updates Readme to reflect changes
