### PR TITLE
Use square bracket syntax for string offset 

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -623,7 +623,7 @@ class PHPGGC
 
         foreach($valid_arguments as $k => $v)
         {
-            $abbreviations[$k] = $k{0};
+            $abbreviations[$k] = $k[0];
         }
 
         $abbreviations = [
@@ -700,7 +700,7 @@ class PHPGGC
                 break;
             }
             # This is a parameter or an option
-            if(strlen($arg) >= 2 && $arg{0} == '-')
+            if(strlen($arg) >= 2 && $arg[0] == '-')
                 $this->_parse_cmdline_arg($i, $argv, $parameters, $options);
             # This is a value
             else


### PR DESCRIPTION
... as curly bracket syntax has been deprecated in PHP 7.4.

Hi there gret tool. 

I ran it under PHP 7.4.7 and got a couple of E_DEPRECATED warnings with message

`PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated ...`

Which cluttered up the terminal. 

 Looks like they are removing that syntax
See https://wiki.php.net/rfc/deprecate_curly_braces_array_access