### PR TITLE
Dockerise the tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:7.3.19-cli-alpine AS builder
+# Can not use > 7.3 (like php:rc-cli-alpine), due to a syntax change. Otherwise the error below will be raised
+# Fatal error: Array and string offset access syntax with curly braces is no longer supported in /phpggc/lib/PHPGGC.php on line 626
+
+COPY . /phpggc
+
+WORKDIR /phpggc
+
+RUN chmod +x phpggc
+
+ENTRYPOINT ["/phpggc/phpggc"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Symfony/RCE2                              2.3.42 < 2.6                   rce    
 Symfony/RCE3                              2.6 <= 2.8.32                  rce              __destruct     *    
 Symfony/RCE4                              3.4.0-34, 4.2.0-11, 4.3.0-7    rce              __destruct     *    
 ThinkPHP/RCE1                             5.1.x-5.2.x                    rce              __destruct     *    
-WordPress/Dompdf/RCE1                     <= 0.8.5+                      rce              __destruct     *    
+WordPress/Dompdf/RCE1                     0.8.5+                         rce              __destruct     *    
 WordPress/Dompdf/RCE2                     0.7.0 <= 0.8.4                 rce              __destruct     *    
 WordPress/Guzzle/RCE1                     4.0.0 <= 6.4.1+                rce              __toString     *    
 WordPress/Guzzle/RCE2                     4.0.0 <= 6.4.1+                rce              __destruct     *    

--- a/gadgetchains/WordPress/Dompdf/RCE/1/chain.php
+++ b/gadgetchains/WordPress/Dompdf/RCE/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\WordPress\Dompdf;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE
 {
-    public static $version = '<= 0.8.5+';
+    public static $version = '0.8.5+';
     public static $vector = '__destruct';
     public static $author = 'erwan_lr';
     public static $informations = '


### PR DESCRIPTION
Same as https://github.com/ambionics/phpggc/pull/75 but in a proper branch

Adds a Dockerfile, to allow users to build a docker image of the tool. This make usage of the tool a bit easier w/o having to install php and so on.

Building:
- `git clone https://github.com/ambionics/phpggc.git && cd phpggc`
- `docker build . -t phpggc`

Usage:
`docker run --rm phpggc`

For example: `docker run --rm phpggc Laravel/RCE1 system id -s`

Beware that when using file input/output options (such as `--pj`, `-o` etc), volumes will have to be mounted via the CLI command to have the files accessible inside the container.

I would recommend you to create a repository on https://hub.docker.com/ and configure an automated build triggered when a commit is done on the GH repo, to automatically build a new image. That way, users will just have to pull the image from Docker with `docker pull phpggc` to get the latest image (rather than build it from the GH repo).

Image Size:
```
% docker images phpggc                                                                                             
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
phpggc              latest              729e97ab7314        15 minutes ago      75.3MB
```
