### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY . /phpggc
 
 WORKDIR /phpggc
 
-RUN chmod +x phpggc
+RUN chmod +x phpggc && echo "phar.readonly=0" > $PHP_INI_DIR/php.ini
 
 ENTRYPOINT ["/phpggc/phpggc"]


### PR DESCRIPTION
`phar.readonly` by default is set to "1" in the docker container. This causes the following error:

```
ERROR: Cannot create phar: phar.readonly is set to 1
```

When generating a phar. This commit disables readonly, allowing the phar to generate