### PR TITLE
Archive_Tar destructor was hardened in Drupal 7.79 so Drupal7/FD1 doe…

### DIFF
--- a/gadgetchains/Drupal7/FD/1/chain.php
+++ b/gadgetchains/Drupal7/FD/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Drupal7;
 
 class FD1 extends \PHPGGC\GadgetChain\FileDelete
 {
-    public static $version = '7.0 < ?';
+    public static $version = '7.0 < 7.79';
     public static $vector = '__destruct';
     public static $author = 'rreiss';
     public static $information = '


### PR DESCRIPTION
…s not work since that release

- https://www.drupal.org/node/3195939
- https://www.drupal.org/project/drupal/releases/7.79