### PR TITLE
Update of the version compatible with the Drupal9/RCE1 exploit

### DIFF
--- a/gadgetchains/Drupal9/RCE/1/chain.php
+++ b/gadgetchains/Drupal9/RCE/1/chain.php
@@ -4,13 +4,13 @@ namespace GadgetChain\Drupal9;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '-8.9.6 <= 9.4.9+';
+    public static $version = '-8.9.6 <= 9.5.10';
     public static $vector = '__destruct';
     public static $author = 'rioru';
     public static $information = 
     'Guzzle and Laminas are required for this chain but are bundled by default in Drupal.
     Uses a __destruct() to call __toString() and finally lands in a call_user_func_array after a few call jumps.
-    Tested on drupal versions from 8.9.6 up to 9.4.9 (latest), might work on slightly older versions.';
+    Tested on drupal versions from 8.9.6 up to 9.5.10 (latest), might work on slightly older versions.';
 
     public function generate(array $parameters)
     {


### PR DESCRIPTION
I've checked the exploitability for Drupal 9.5.10, and it works!