### PR TITLE
Fixed PHP Code Gadget Chains: Doctrine/RCE1 | Horde/RCE1 | Laravel/RCE5 | PHPSecLib/RCE1 | Symfony/RCE3 | ZendFramework/RCE1 | ZendFramework/RCE4

### DIFF
--- a/gadgetchains/Doctrine/RCE/1/chain.php
+++ b/gadgetchains/Doctrine/RCE/1/chain.php
@@ -44,7 +44,11 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         $replace_include = 'i:' . 2000 . ';';
         return preg_replace($find_include, $replace_include, $serialized2);
   	}
-
+    
+    public static $parameters = [
+        'code'
+    ];
+    
     public function generate(array $parameters)
     {
         $code = $parameters['code'];

--- a/gadgetchains/Horde/RCE/1/chain.php
+++ b/gadgetchains/Horde/RCE/1/chain.php
@@ -13,6 +13,10 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         See https://srcincite.io/blog/2020/08/19/a-smorgashorde-of-vulnerabilities-a-comparative-analysis-of-discovery.html
     ';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
 	    $code = $parameters['code'] . ';die;';

--- a/gadgetchains/Laravel/RCE/5/chain.php
+++ b/gadgetchains/Laravel/RCE/5/chain.php
@@ -12,6 +12,10 @@ class RCE5 extends \PHPGGC\GadgetChain\RCE\PHPCode
         Requires Mockery, which is in the require-dev package. 
     ';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
         $code = '<?php ' . $parameters['code'] . ' exit; ?>';

--- a/gadgetchains/PHPSecLib/RCE/1/chain.php
+++ b/gadgetchains/PHPSecLib/RCE/1/chain.php
@@ -9,6 +9,10 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
     public static $author = 'crlf';
     public static $information = 'Generates warnings and notices.';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
         $code = $parameters['code'];

--- a/gadgetchains/Symfony/RCE/3/chain.php
+++ b/gadgetchains/Symfony/RCE/3/chain.php
@@ -9,6 +9,10 @@ class RCE3 extends \PHPGGC\GadgetChain\RCE\PHPCode
     public static $author = 'crlf';
     public static $information = 'Executes through eval() ( <?php \'.$code.\';die(); ?> )';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
         $code = $parameters['code'];

--- a/gadgetchains/ZendFramework/RCE/1/chain.php
+++ b/gadgetchains/ZendFramework/RCE/1/chain.php
@@ -14,6 +14,10 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\PHPCode
         - Payload gets executed twice
     ';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
         $code = $parameters['code'];

--- a/gadgetchains/ZendFramework/RCE/4/chain.php
+++ b/gadgetchains/ZendFramework/RCE/4/chain.php
@@ -13,6 +13,10 @@ class RCE4 extends \PHPGGC\GadgetChain\RCE\PHPCode
         - Works on PHP >= 7.0.0
     ';
 
+    public static $parameters = [
+        'code'
+    ];
+
     public function generate(array $parameters)
     {
         return new \Zend_Log(


### PR DESCRIPTION
Hello, when attempting to utilize any of the following PHP Code Gadget Chains `Doctrine/RCE1 Horde/RCE1 Laravel/RCE5 PHPSecLib/RCE1 Symfony/RCE3 ZendFramework/RCE1 ZendFramework/RCE4`

The message **"ERROR: Invalid arguments for type "RCE: PHP Code""** was received.
<img width="537" alt="1" src="https://github.com/ambionics/phpggc/assets/96009982/6a2c09ac-fb1e-4916-96bd-92ade3a360cd">

Generating these PHP Code gadget chains was only feasible without passing any arguments, necessitating direct editing within the PHP object.
<img width="1280" alt="2" src="https://github.com/ambionics/phpggc/assets/96009982/949a1667-64a4-46b1-a6f8-de7fa19b8629">

The solution that proved effective was adding this code snippet to the `chain.php` files located at `gadgetchains/{gadget}/RCE/{id}/chain.php` when generating the gadgets: `public static $parameters = ['code'];`
<img width="1280" alt="3" src="https://github.com/ambionics/phpggc/assets/96009982/cb0514e8-2b2f-4739-9315-3d3cc4a48df3">

