### PR TITLE
Avoid phar.readonly warning

### DIFF
--- a/phpggc
+++ b/phpggc
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/env php -d phar.readonly=0
 <?php
 
 error_reporting(E_ALL);


### PR DESCRIPTION
Disable phar.readonly to ensure smooth phar payload generation