### PR TITLE
Update shebang to use env -S

### DIFF
--- a/phpggc
+++ b/phpggc
@@ -1,4 +1,4 @@
-#!/usr/bin/env php -d phar.readonly=0
+#!/usr/bin/env -S php -d phar.readonly=0
 <?php
 
 error_reporting(E_ALL);


### PR DESCRIPTION
As described [in the coreutils manual](https://www.gnu.org/software/coreutils/manual/coreutils.html#g_t_002dS_002f_002d_002dsplit_002dstring-usage-in-scripts), `-S` is "used to pass multiple arguments on shebang lines". Fixes #163.