### PR TITLE
Update gadgets chain class name to RCE20 in order to avoid conflict

### DIFF
--- a/gadgetchains/Laravel/RCE/20/chain.php
+++ b/gadgetchains/Laravel/RCE/20/chain.php
@@ -2,7 +2,7 @@
 
 namespace GadgetChain\Laravel;
 
-class RCE19 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+class RCE20 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
     public static $version = '5.6 <= 10.x';
     public static $vector = '__destruct';


### PR DESCRIPTION
Update class name to RCE20 to avoid this type of conflict:

```bash
$ ./phpggc Laravel/RCE20 phpinfo 1
PHP Fatal error:  Cannot declare class GadgetChain\Laravel\RCE19, because the name is already in use in phpggc/gadgetchains/Laravel/RCE/19/chain.php on line 5

Fatal error: Cannot declare class GadgetChain\Laravel\RCE19, because the name is already in use in phpggc/gadgetchains/Laravel/RCE/19/chain.php on line 5
```