### PR TITLE
Fixed version for Drupal7/RCE1

### DIFF
--- a/gadgetchains/Drupal7/RCE/1/chain.php
+++ b/gadgetchains/Drupal7/RCE/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Drupal7;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '7.0.8 < ?';
+    public static $version = '7.0.8 <= 7.98';
     public static $vector = '__destruct';
     public static $author = 'Blaklis';
     public static $information = 'You will need to post form_build_id=DrupalRCE to /?q=system/ajax once the payload is unserialized';


### PR DESCRIPTION
Drupal 7.99, released on 2023-12-06, includes a fix that means this gadget chain no longer works. Sorry :)

- https://www.drupal.org/project/drupal/releases/7.99
- https://www.drupal.org/node/3381030
- https://www.drupal.org/node/3378257