### PR TITLE
WordPress/RCE2: Update vulnerable versions

### DIFF
--- a/gadgetchains/WordPress/RCE/2/chain.php
+++ b/gadgetchains/WordPress/RCE/2/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\WordPress;
 
 class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '6.4.0+';
+    public static $version = '6.4.0 <= 6.4.1';
     public static $vector = '__destruct';
     public static $author = 'Fenrisk (Szlam)';
     public static $information = '';


### PR DESCRIPTION
This chain was patched in https://github.com/WordPress/WordPress/commit/46406afcc4cc938f44115c49ae775bad52039710.