### PR TITLE
Introduce --session-encode/-se option

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -194,7 +194,10 @@ final class PHPGGC
         $parameters = $this->process_parameters($gc, $parameters);
         $object = $gc->generate($parameters);
         $object = $this->process_object($gc, $object);
-        $serialized = serialize($object);
+        if(in_array('session-encode', $this->options))
+            $serialized = $this->session_encode($object);
+        else
+            $serialized = serialize($object);
         $serialized = $this->process_serialized($gc, $serialized);
         return $serialized;
     }
@@ -365,6 +368,26 @@ final class PHPGGC
 
         $phar = new $class($serialized, compact('prefix', 'filename', 'jpeg'));
         return $phar->generate();
+    }
+
+    #
+    # Session Encode
+    #
+
+    /**
+     * Uses session_encode() instead of serialize().
+     * 
+     * This is useful if you have an existing arbitrary file write primitive, but the
+     * web root directory is non-writable. In such cases, it is possible to forge a 
+     * session file containing an unserialize() payload and trigger the chain by 
+     * visiting any webpage that invokes session_start().
+     */
+    function session_encode($object)
+    {
+        $_SESSION['_'] = $object;
+        $serialized = session_encode();
+        session_destroy();
+        return $serialized;
     }
 
     /**
@@ -555,6 +578,10 @@ final class PHPGGC
         $this->o('  -pf, --phar-filename <filename>');
         $this->o('     Defines the name of the file contained in the generated PHAR (default: test.txt)');
         $this->o('');
+        $this->o('SESSION ENCODE');
+        $this->o('  -se, --session-encode');
+        $this->o('     Uses session_encode() instead of serialize() to generate the payload.');
+        $this->o('');
         $this->o('ENHANCEMENTS');
         $this->o('  -f, --fast-destruct');
         $this->o('     Applies the fast-destruct technique, so that the object is destroyed');
@@ -649,6 +676,8 @@ final class PHPGGC
             'phar-jpeg' => true,
             'phar-prefix' => true,
             'phar-filename' => true,
+            # Session Encode
+            'session-encode' => false,
             # Enhancements
             'fast-destruct' => false,
             'ascii-strings' => false,
@@ -676,7 +705,8 @@ final class PHPGGC
             'phar-filename' => 'pf',
             'new' => 'N',
             'ascii-strings' => 'a',
-            'armor-strings' => 'A'
+            'armor-strings' => 'A',
+            'session-encode' => 'se',
         ] + $abbreviations;
 
         # If we are in this function, the argument starts with a dash, so we
@@ -783,6 +813,10 @@ final class PHPGGC
                     $this->o($gc, 2);
                     $this->o($this->_get_command_line_gc($gc));
                     return;
+                case 'session-encode':
+                    session_name('phpggc');
+                    session_start();
+                    break;
             }
         }
 


### PR DESCRIPTION
Hey Charles,

I'm suggesting a new option, `--session-encode`/`-se` to allow generation of payloads using `session_encode()` instead of `serialize()`.

The rationale behind introducing this option is documented in the changes as well:
> This is useful if you have an existing arbitrary file write primitive, but the web root directory is non-writable. In such cases, it is possible to forge a session file containing an `unserialize()` payload and trigger the chain by visiting any webpage that invokes `session_start()`.

Since introducing the `--session-encode` option as an enhancement, wrapper or encoder would require deserialising the payload and re-serialising it with `session_encode()`, I opted to implement this in `PHPGGC::serialize()`.

