### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM php:8.1-cli-alpine AS builder
 
-RUN apk add python3 py3-pip curl
+RUN apk add python3 py3-pip py3-rich curl
 
 RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 
 RUN alias composer='php /usr/bin/composer'
 
-RUN pip install rich
-
 COPY . /phpggc
 
 WORKDIR /phpggc
 
-RUN chmod +x phpggc && echo "phar.readonly=0" > $PHP_INI_DIR/php.ini
+RUN sed -i '1s|.*|#!/usr/bin/env php|' phpggc && chmod +x phpggc && echo "phar.readonly=0" > $PHP_INI_DIR/php.ini
 
 ENTRYPOINT ["/phpggc/phpggc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.1-cli-alpine AS builder
 
-RUN apk add python3 py3-pip py3-rich curl
+RUN apk add python3 py3-rich curl
 
 RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 


### PR DESCRIPTION
Hi! When I was trying to run PHPGGC using Docker, I encountered 2 issues.

1). Build fails because of `RUN pip install rich`, as shown on the screenshot.

![image](https://github.com/ambionics/phpggc/assets/34795180/23edbdd8-4011-409f-9fea-54d7f7219de1)

Replacing this command with a system-wide installation of `py3-rich` package via `apk` solved this issue and allowed to successfully build the image.

2). BusyBox `env` doesn't have an `-S` flag.

![image](https://github.com/ambionics/phpggc/assets/34795180/0689932e-fa22-4bc1-ac5c-fc2c4a4938f5)

That's what I saw when running the image for the first time. I resolved this issue by changing the shebang of `phpggc` script to just `#!/usr/bin/env php`. Considering that the `phar.readonly` option is set via `php.ini` (when using Docker), it seems to be an appropriate solution. In order to not modify the script itself or to create a copy, I replace the shebang with `sed` during build.

With these fixes I managed to finally use the tool (which is awesome btw!)

UPD: only after creating the PR I realized that because of the issue with `rich`, installing `pip` is not necessary anymore :) So perhaps it is also worth removing it from `RUN apk add` command to reduce image size (which was done in the second commit)