### PR TITLE
Use RFC3986-compliant URL-encoding for url and soft encoders

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -432,11 +432,11 @@ final class PHPGGC
                     $serialized = base64_encode($serialized);
                     break;
                 case 'url':
-                    $serialized = urlencode($serialized);
+                    $serialized = rawurlencode($serialized);
                     break;
                 case 'soft':
                     $keys = str_split("%\x00\n\r\t+; ");
-                    $values = array_map('urlencode', $keys);
+                    $values = array_map('rawurlencode', $keys);
                     $serialized = str_replace($keys, $values, $serialized);
                     break;
                 case 'json':


### PR DESCRIPTION
Fixes #189.