### PR TITLE
Update FunctionCall.php: $type_description => "Function Call"

### DIFF
--- a/lib/PHPGGC/GadgetChain/RCE/FunctionCall.php
+++ b/lib/PHPGGC/GadgetChain/RCE/FunctionCall.php
@@ -9,7 +9,7 @@ namespace PHPGGC\GadgetChain\RCE;
  */
 abstract class FunctionCall extends \PHPGGC\GadgetChain\RCE
 {
-    public static $type_description = 'RCE: Command';
+    public static $type_description = 'RCE: Function Call';
 
     public static $parameters = [
         'function',


### PR DESCRIPTION
Hello,

I made a change to `FunctionCall.php` to provide better information when users use `./phpggc -l`.

Thank you for sharing PHPGGC, wrapwrap, cnext, ... 🙏