### PR TITLE
Fixing Symfony/RCE/14: PHP Fatal error in PHP >5

### DIFF
--- a/gadgetchains/Symfony/RCE/14/gadgets.php
+++ b/gadgetchains/Symfony/RCE/14/gadgets.php
@@ -6,6 +6,7 @@ class PropelDateTime extends DateTime
 	private $tzString;
 
   public function __construct($dateString, $tzString) {
+    parent::__construct();
     $this->dateString = $dateString;
     $this->tzString = $tzString;
   }


### PR DESCRIPTION
In Symfony/RCE/14, the PropelDateTime class did not initialized the parent DateTime object causing the error : `PHP Fatal error:  Uncaught Error: The DateTime object has not been correctly initialized by its constructor`

In PHP5, it did not seem to cause issue, but it did in higher versions like php8.