### PR TITLE
Fix: deprecation message for Monolog-RCE{8, 9} and a few changes ...

### DIFF
--- a/gadgetchains/Monolog/FW/1/chain.php
+++ b/gadgetchains/Monolog/FW/1/chain.php
@@ -7,7 +7,7 @@ class FW1 extends \PHPGGC\GadgetChain\FileWrite
     public static $version = '3.0.0 <= 3.1.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein (Mirhossein Rahmani)';
-    public static $information = 'Please use this GC only for educational purposes or legal pentest, Thank you!';
+    public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Monolog/FW/1/chain.php
+++ b/gadgetchains/Monolog/FW/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class FW1 extends \PHPGGC\GadgetChain\FileWrite
 {
-    public static $version = '3.0.0 <= 3.1.0+';
+    public static $version = '3.0.0 <= 3.9.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';

--- a/gadgetchains/Monolog/RCE/1/chain.php
+++ b/gadgetchains/Monolog/RCE/1/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.4.1 <= 1.6.0 1.17.2 <= 2.7.0+';
+    public static $version = '1.4.1 <= 1.6.0 1.17.2 <= 2.10.0+';
     public static $vector = '__destruct';
     public static $author = 'cfreal';
 

--- a/gadgetchains/Monolog/RCE/2/chain.php
+++ b/gadgetchains/Monolog/RCE/2/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.4.1 <= 2.7.0+';
+    public static $version = '1.4.1 <= 2.10.0+';
     public static $vector = '__destruct';
     public static $author = 'cfreal';
 

--- a/gadgetchains/Monolog/RCE/5/chain.php
+++ b/gadgetchains/Monolog/RCE/5/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE5 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.25 <= 2.7.0+';
+    public static $version = '1.25 <= 2.10.0+';
     public static $vector = '__destruct';
     public static $author = 'mayfly';
 

--- a/gadgetchains/Monolog/RCE/6/chain.php
+++ b/gadgetchains/Monolog/RCE/6/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE6 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.10.0 <= 2.7.0+';
+    public static $version = '1.10.0 <= 2.10.0+';
     public static $vector = '__destruct';
     public static $author = 'mayfly';
 

--- a/gadgetchains/Monolog/RCE/7/chain.php
+++ b/gadgetchains/Monolog/RCE/7/chain.php
@@ -7,7 +7,7 @@ class RCE7 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '1.10.0 <= 2.7.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein';
-    public static $information = 'Please use this exploit only for educational purposes or legal pentest, thank you!';
+    public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Monolog/RCE/7/chain.php
+++ b/gadgetchains/Monolog/RCE/7/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE7 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '1.10.0 <= 2.7.0+';
+    public static $version = '1.10.0 <= 2.10.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';

--- a/gadgetchains/Monolog/RCE/7/chain.php
+++ b/gadgetchains/Monolog/RCE/7/chain.php
@@ -6,7 +6,7 @@ class RCE7 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
     public static $version = '1.10.0 <= 2.7.0+';
     public static $vector = '__destruct';
-    public static $author = 'mir-hossein';
+    public static $author = 'mir-hossein (Mirhossein Rahmani)7';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)

--- a/gadgetchains/Monolog/RCE/7/chain.php
+++ b/gadgetchains/Monolog/RCE/7/chain.php
@@ -6,7 +6,7 @@ class RCE7 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
     public static $version = '1.10.0 <= 2.7.0+';
     public static $vector = '__destruct';
-    public static $author = 'mir-hossein (Mirhossein Rahmani)7';
+    public static $author = 'mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)

--- a/gadgetchains/Monolog/RCE/8/chain.php
+++ b/gadgetchains/Monolog/RCE/8/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE8 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '3.0.0 <= 3.1.0+';
+    public static $version = '3.0.0 <= 3.9.0+';
     public static $vector = '__destruct';
     public static $author = 'cf (Charles Fol), mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';

--- a/gadgetchains/Monolog/RCE/8/chain.php
+++ b/gadgetchains/Monolog/RCE/8/chain.php
@@ -7,7 +7,7 @@ class RCE8 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '3.0.0 <= 3.1.0+';
     public static $vector = '__destruct';
     public static $author = 'cf (Charles Fol), mir-hossein (Mirhossein Rahmani)';
-    public static $information = 'Please use this exploit only for educational purposes or legal pentest, Thank you!';
+    public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Monolog/RCE/8/gadgets.php
+++ b/gadgetchains/Monolog/RCE/8/gadgets.php
@@ -15,7 +15,7 @@ namespace Monolog
         function __construct($parameter)
         {
             $this->level = \Monolog\Level::Debug;
-            $this->mixed = $parameter;
+            $this->formatted = $parameter;
         }
     }
 }

--- a/gadgetchains/Monolog/RCE/9/chain.php
+++ b/gadgetchains/Monolog/RCE/9/chain.php
@@ -7,7 +7,7 @@ class RCE9 extends \PHPGGC\GadgetChain\RCE\FunctionCall
     public static $version = '3.0.0 <= 3.1.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein (Mirhossein Rahmani)';
-    public static $information = 'Please use this exploit only for educational purposes or legal pentest, Thank you!';
+    public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';
 
     public function generate(array $parameters)
     {

--- a/gadgetchains/Monolog/RCE/9/chain.php
+++ b/gadgetchains/Monolog/RCE/9/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\Monolog;
 
 class RCE9 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '3.0.0 <= 3.1.0+';
+    public static $version = '3.0.0 <= 3.9.0+';
     public static $vector = '__destruct';
     public static $author = 'mir-hossein (Mirhossein Rahmani)';
     public static $information = 'Please use this GC only for educational purposes or legal penetration testing. Thank you!';

--- a/gadgetchains/Monolog/RCE/9/gadgets.php
+++ b/gadgetchains/Monolog/RCE/9/gadgets.php
@@ -32,7 +32,7 @@ namespace Monolog
         
         function __construct($parameter)
         {
-            $this->mixed = $parameter;
+            $this->formatted = $parameter;
         }
     }
 }

--- a/lib/PHPGGC/GadgetChain/RCE.php
+++ b/lib/PHPGGC/GadgetChain/RCE.php
@@ -11,6 +11,9 @@ abstract class RCE extends \PHPGGC\GadgetChain
     # TBD by subclasses
     public static $parameters = [];
 
+    public $__test_rand_token;
+    public $__test_rand_path;
+    
     /**
      * The result of the command is not necessarily visible. We write the output
      * to a file instead to be able to tell if the payload worked, even if


### PR DESCRIPTION
Hello,

Monolog/RCE{8,9} generated a deprecation message because of a typo.

The issue has been solved now, and a few changes have been made.

Thank you for sharing PHPGGC!