### PR TITLE
public-properties should happen before wrapper enhancement

### DIFF
--- a/lib/PHPGGC.php
+++ b/lib/PHPGGC.php
@@ -170,12 +170,12 @@ final class PHPGGC
             );
         }
 
+        if(in_array('public-properties', $this->options))
+            $enhancements[] = new Enhancement\PublicProperties();
         if(isset($this->parameters['wrapper']))
             $enhancements[] = new Enhancement\Wrapper($this->parameters['wrapper']);
         if(in_array('fast-destruct', $this->options))
             $enhancements[] = new Enhancement\FastDestruct();
-        if(in_array('public-properties', $this->options))
-            $enhancements[] = new Enhancement\PublicProperties();
         if(in_array('ascii-strings', $this->options))
             $enhancements[] = new Enhancement\ASCIIStrings(false);
         if(in_array('armor-strings', $this->options))


### PR DESCRIPTION
Noticed recently that the public-properties enhancement often does not work if you also use a wrapper.

Perhaps it depends on what the wrapper does, but if it e.g. encodes the serialized payload it's too late for public-properties to try to remove prefixes from classes after that.

I think in most cases it would work better to do public-properties before a wrapper.

This fixes the problem I was seeing.

Are there times when you'd want to do the wrapper first? If so perhaps we can make the order configurable.